### PR TITLE
Remove start script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lint": "yarn lint-package-json && yarn lint-js",
     "prepublishOnly": "yarn clean && yarn install && yarn build",
     "serve": "yarn docs",
-    "start": "react-scripts start",
     "test": "react-scripts test"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Done
Remove `start` script from `package.json` as it fails due to there being no `public/` directory. This script is left over from the projects initialisation with [create-react-app](https://github.com/facebook/create-react-app) and is not intended for use on this project. Fixes #37.

## QA
- Clone this repo
- Run `yarn start`
- See that you get the following error: `error Command "start" not found.` indicating that there is no `start` script 