### PR TITLE
Fix Notification timeout function not being executed.

### DIFF
--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -21,7 +21,7 @@ const Notification = ({
   const timeoutId = useRef();
 
   useEffect(() => {
-    if (timeout && close && !timeoutId.current) {
+    if (timeout && close) {
       timeoutId.current = setTimeout(() => close(), timeout);
     }
     return () => clearTimeout(timeoutId.current);


### PR DESCRIPTION
## Done
- Fixed Notification timeout function not being executed, despite being provided timeout and close props.

## QA
- `yarn link` this project and `/node_modules/react` and link them in `maas-ui`.
- Go to <maas-ui-url>:8400/MAAS/r/account/prefs/details.
- Change your details and check that the notification closes after five seconds.

Fixes canonical-web-and-design/maas-ui#517