### PR TITLE
Add dense buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Button component now supports is-dense.
+- User supplied Button classes are now inserted after those added by the component.
+
 ### Changed
 
 ### Removed

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -6,6 +6,7 @@ const Button = ({
   appearance = "neutral",
   children,
   className,
+  dense,
   disabled,
   element: Component = "button",
   hasIcon,
@@ -13,11 +14,16 @@ const Button = ({
   onClick,
   ...props
 }) => {
-  const classes = classNames(className, `p-button--${appearance}`, {
-    "has-icon": hasIcon,
-    "is-disabled": (Component !== "button") & disabled,
-    "is-inline": inline
-  });
+  const classes = classNames(
+    `p-button--${appearance}`,
+    {
+      "has-icon": hasIcon,
+      "is-dense": dense,
+      "is-disabled": (Component !== "button") & disabled,
+      "is-inline": inline
+    },
+    className
+  );
   const onClickDisabled = e => e.preventDefault();
   const commonProps = {
     ...props,
@@ -44,6 +50,7 @@ Button.propTypes = {
   appearance: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  dense: PropTypes.bool,
   disabled: PropTypes.bool,
   element: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -49,6 +49,7 @@ Buttons are clickable elements used to perform an action, they can be used for b
 </Preview>
 
 ### Neutral
+
 <Preview>
   <Story name="Neutral">
     <Button appearance="neutral">Neutral button</Button>
@@ -115,10 +116,23 @@ Buttons are clickable elements used to perform an action, they can be used for b
 
 <Preview>
   <Story name="Inline">
-    <span>Everything you need to get started with Vanilla. </span>
-    <Button appearance="neutral" inline>
-      Inline button
-    </Button>
+    <>
+      <span>Everything you need to get started with Vanilla. </span>
+      <Button appearance="neutral" inline>
+        Inline button
+      </Button>
+    </>
+  </Story>
+</Preview>
+
+### Dense
+
+<Preview>
+  <Story name="Dense">
+    <>
+      <span>Everything you need to get started with Vanilla. </span>
+      <Button dense>Dense button</Button>
+    </>
   </Story>
 </Preview>
 

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -63,10 +63,22 @@ describe("Button ", () => {
     expect(wrapper.prop("className").includes("is-inline")).toBe(true);
   });
 
+  it("can be dense", () => {
+    const wrapper = shallow(<Button dense />);
+    expect(wrapper.prop("className").includes("is-dense")).toBe(true);
+  });
+
   it("can add additional classes", () => {
     const wrapper = shallow(<Button className="extra-class" />);
     const className = wrapper.prop("className");
     expect(className.includes("p-button--neutral")).toBe(true);
     expect(className.includes("extra-class")).toBe(true);
+  });
+
+  it("puts additional classes at the end", () => {
+    const wrapper = shallow(<Button className="extra-class" dense />);
+    expect(wrapper.prop("className")).toEqual(
+      "p-button--neutral is-dense extra-class"
+    );
   });
 });


### PR DESCRIPTION
Done:
- Add the dense option to the Button component. Fixes: https://github.com/canonical-web-and-design/react-components/issues/43.


QA:
- Run storybook and see that the Button component has a dense option.