### PR TITLE
SearchBox external state control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 
 .docker-project
 .yarn.*
+.dotrun.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint": "yarn lint-package-json && yarn lint-js",
     "prepublishOnly": "yarn clean && yarn install && yarn build",
     "serve": "yarn docs",
+    "start": "yarn docs",
     "test": "react-scripts test"
   },
   "eslintConfig": {

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const SearchBox = ({
-  disabled,
   className,
+  disabled,
+  externallyControlled,
   onChange,
   onSubmit,
   placeholder = "Search",
@@ -34,7 +35,8 @@ const SearchBox = ({
         placeholder={placeholder}
         ref={input}
         type="search"
-        defaultValue={value}
+        defaultValue={externallyControlled ? undefined : value}
+        value={externallyControlled ? value : undefined}
       />
       {value && (
         <button
@@ -62,6 +64,10 @@ const SearchBox = ({
 SearchBox.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  /**
+   * Whether the input value will be controlled via external state.
+   */
+  externallyControlled: PropTypes.bool,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   placeholder: PropTypes.string,

--- a/src/components/SearchBox/SearchBox.stories.mdx
+++ b/src/components/SearchBox/SearchBox.stories.mdx
@@ -30,6 +30,18 @@ Search boxes enable search functionality on a page and are typically used in a n
   </Story>
 </Preview>
 
+### External state
+
+If you wish to control the value of the input via external state you can set
+the `externallyControlled` prop and provide an `onChange` method to update the
+state and the `value` from state.
+
+<Preview>
+  <Story name="External state">
+    <SearchBox externallyControlled onChange={() => {}} value="..." />
+  </Story>
+</Preview>
+
 ### Navigation
 
 <Preview>

--- a/src/components/SearchBox/SearchBox.test.js
+++ b/src/components/SearchBox/SearchBox.test.js
@@ -13,4 +13,16 @@ describe("SearchBox ", () => {
     const wrapper = shallow(<SearchBox value="admin" />);
     expect(wrapper.find(".p-search-box__reset").exists()).toBe(true);
   });
+
+  it("can externally control the value", () => {
+    const wrapper = shallow(
+      <SearchBox externallyControlled onChange={jest.fn()} value="admin" />
+    );
+    let input = wrapper.find(".p-search-box__input");
+    expect(input.prop("defaultValue")).toBe(undefined);
+    expect(input.prop("value")).toBe("admin");
+    wrapper.setProps({ value: "new-admin" });
+    input = wrapper.find(".p-search-box__input");
+    expect(input.prop("value")).toBe("new-admin");
+  });
 });


### PR DESCRIPTION
Done:
- Allow the search box to be controlled by external state.

QA:
- There's probably no easy way to QA this change without using the component. Make sure the component looks and functions as before.

Fixes #76 