### PR TITLE
Fix warning about aria prop

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -22,7 +22,7 @@ const Accordion = ({ className, sections, ...props }) => {
       className={classNames(className, "p-accordion")}
       {...props}
       role="tablist"
-      ariaMultiselectable="true"
+      aria-multiselectable="true"
     >
       <ul className="p-accordion__list">
         {generateSections(sections, setExpanded, expanded)}

--- a/src/components/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Accordion  renders 1`] = `
 <aside
-  ariaMultiselectable="true"
+  aria-multiselectable="true"
   className="p-accordion"
   role="tablist"
 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,7 +2352,7 @@
     percy-client "^3.0.0"
     slugify "^1.1.0"
 
-"@percy/storybook@^3.3.0":
+"@percy/storybook@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@percy/storybook/-/storybook-3.3.0.tgz#7ebdf2a0f6e09924b82045a755a2e2fbc6704581"
   integrity sha512-xo6wIZUhrR07K5iTjTRUK0jXWhIYsP4yjUNjqNVwsuYS+aDD+1ZGd+2ZI0IrfTcllUkA6MUgtP1qMRhpx9hZ6g==


### PR DESCRIPTION
Done:
- Fix aria prop warning. Fixes: https://github.com/canonical-web-and-design/react-components/issues/74.

QA:
- Open storybook and navigate to the accordion page. You shouldn't get a warning about `Warning: Invalid ARIA attribute ariaMultiselectable`.