### PR TITLE
Add click events to Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade Vanilla Framework to 2.9.0.
+- Added click event props to Accordion.
+
 ### Removed
 
 ## [0.4.0] - 2020-03-11

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -5,18 +5,21 @@ import React, { useState } from "react";
 import AccordionSection from "../AccordionSection";
 
 const generateSections = (sections, setExpanded, expanded) =>
-  sections.map(({ content, title }, i) => (
+  sections.map((props, i) => (
     <AccordionSection
-      content={content}
       expanded={expanded}
       key={i}
       setExpanded={setExpanded}
-      title={title}
+      {...props}
     />
   ));
 
-const Accordion = ({ className, sections, ...props }) => {
+const Accordion = ({ className, onExpandedChange, sections, ...props }) => {
   const [expanded, setExpanded] = useState();
+  const changeExpanded = (id, title) => {
+    setExpanded(id);
+    onExpandedChange && onExpandedChange(title);
+  };
   return (
     <aside
       className={classNames(className, "p-accordion")}
@@ -25,7 +28,7 @@ const Accordion = ({ className, sections, ...props }) => {
       aria-multiselectable="true"
     >
       <ul className="p-accordion__list">
-        {generateSections(sections, setExpanded, expanded)}
+        {generateSections(sections, changeExpanded, expanded)}
       </ul>
     </aside>
   );
@@ -42,6 +45,10 @@ Accordion.propTypes = {
   sections: PropTypes.arrayOf(
     PropTypes.shape({
       /**
+       * An optional click event when the title is clicked.
+       */
+      onTitleClick: PropTypes.func,
+      /**
        * The title of the section.
        */
       title: PropTypes.string,
@@ -50,7 +57,12 @@ Accordion.propTypes = {
        */
       content: PropTypes.node
     }).isRequired
-  )
+  ),
+  /**
+   * Optional function that is called when the expanded section is changed.
+   * The function is provided the section title or null.
+   */
+  onExpandedChange: PropTypes.func
 };
 
 export default Accordion;

--- a/src/components/Accordion/Accordion.test.js
+++ b/src/components/Accordion/Accordion.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Accordion from "./Accordion";
@@ -24,6 +24,31 @@ describe("Accordion ", () => {
       />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can call a function when a section is expanded", () => {
+    const onExpandedChange = jest.fn();
+    const wrapper = mount(
+      <Accordion
+        onExpandedChange={onExpandedChange}
+        sections={[
+          {
+            title: "Advanced topics",
+            content: "test content"
+          },
+          {
+            title: "Networking",
+            content: <>More test content</>
+          }
+        ]}
+      />
+    );
+    const title = wrapper.find(".p-accordion__tab").at(0);
+    title.simulate("click");
+    expect(onExpandedChange).toHaveBeenCalledWith("Advanced topics");
+    // Clicking the title again should close the accordion section.
+    title.simulate("click");
+    expect(onExpandedChange).toHaveBeenCalledWith(null);
   });
 
   it("can add additional classes", () => {

--- a/src/components/AccordionSection/AccordionSection.js
+++ b/src/components/AccordionSection/AccordionSection.js
@@ -2,7 +2,13 @@ import PropTypes from "prop-types";
 import React, { useRef } from "react";
 import uuidv4 from "uuid/v4";
 
-const AccordionSection = ({ content, expanded, setExpanded, title }) => {
+const AccordionSection = ({
+  content,
+  expanded,
+  onTitleClick,
+  setExpanded,
+  title
+}) => {
   const buttonId = useRef(uuidv4());
   const sectionId = useRef(uuidv4());
   const isExpanded = expanded === buttonId.current;
@@ -13,7 +19,14 @@ const AccordionSection = ({ content, expanded, setExpanded, title }) => {
         aria-expanded={isExpanded ? "true" : "false"}
         className="p-accordion__tab"
         id={buttonId.current}
-        onClick={() => setExpanded(isExpanded ? null : buttonId.current)}
+        onClick={() => {
+          if (isExpanded) {
+            setExpanded(null, null);
+          } else {
+            setExpanded(buttonId.current, title);
+          }
+          onTitleClick && onTitleClick(!isExpanded);
+        }}
         role="tab"
         type="button"
       >
@@ -35,6 +48,10 @@ const AccordionSection = ({ content, expanded, setExpanded, title }) => {
 AccordionSection.propTypes = {
   content: PropTypes.node,
   expanded: PropTypes.string,
+  /**
+   * An optional click event when the title is clicked.
+   */
+  onTitleClick: PropTypes.func,
   setExpanded: PropTypes.func,
   title: PropTypes.string
 };

--- a/src/components/AccordionSection/AccordionSection.test.js
+++ b/src/components/AccordionSection/AccordionSection.test.js
@@ -19,4 +19,32 @@ describe("AccordionSection ", () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("can handle click events on the title", () => {
+    const onTitleClick = jest.fn();
+    let expanded = null;
+    const wrapper = shallow(
+      <AccordionSection
+        content={<span>Test</span>}
+        expanded={expanded}
+        onTitleClick={onTitleClick}
+        setExpanded={id => {
+          expanded = id;
+        }}
+        title="Test section"
+      />
+    );
+    wrapper
+      .find(".p-accordion__tab")
+      .at(0)
+      .simulate("click");
+    expect(onTitleClick.mock.calls[0][0]).toBe(true);
+    wrapper.setProps({ expanded });
+    // Clicking the title again should close the accordion section.
+    wrapper
+      .find(".p-accordion__tab")
+      .at(0)
+      .simulate("click");
+    expect(onTitleClick.mock.calls[1][0]).toBe(false);
+  });
 });


### PR DESCRIPTION
Done:
- Add events when the Accordion sections are opened and closed.

QA:
- There's no really easy way to QA this without adding those props. See me if you want to QA this.