### PR TITLE
Add loading prop to SearchBox.

### DIFF
--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -2,10 +2,13 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
+import "./SearchBox.scss";
+
 const SearchBox = ({
   className,
   disabled,
   externallyControlled,
+  loading,
   onChange,
   onSubmit,
   placeholder = "Search",
@@ -38,6 +41,11 @@ const SearchBox = ({
         defaultValue={externallyControlled ? undefined : value}
         value={externallyControlled ? value : undefined}
       />
+      {loading && (
+        <p className="p-search-box__spinner">
+          <i className="p-icon--spinner u-animation--spin"></i>
+        </p>
+      )}
       {value && (
         <button
           alt="reset"
@@ -68,6 +76,7 @@ SearchBox.propTypes = {
    * Whether the input value will be controlled via external state.
    */
   externallyControlled: PropTypes.bool,
+  loading: PropTypes.bool,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   placeholder: PropTypes.string,

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -1,0 +1,5 @@
+@import "~vanilla-framework/scss/settings_spacing";
+
+.p-search-box__spinner {
+  margin: 0 $sph-outer 0 0;
+}

--- a/src/components/SearchBox/SearchBox.stories.mdx
+++ b/src/components/SearchBox/SearchBox.stories.mdx
@@ -30,6 +30,14 @@ Search boxes enable search functionality on a page and are typically used in a n
   </Story>
 </Preview>
 
+### Loading
+
+<Preview>
+  <Story name="Loading">
+    <SearchBox loading />
+  </Story>
+</Preview>
+
 ### External state
 
 If you wish to control the value of the input via external state you can set

--- a/src/components/SearchBox/SearchBox.test.js
+++ b/src/components/SearchBox/SearchBox.test.js
@@ -25,4 +25,11 @@ describe("SearchBox ", () => {
     input = wrapper.find(".p-search-box__input");
     expect(input.prop("value")).toBe("new-admin");
   });
+
+  it("can show a spinner if given loading prop", () => {
+    const wrapper = shallow(
+      <SearchBox loading onChange={jest.fn()} value="" />
+    );
+    expect(wrapper.find(".p-search-box__spinner").exists()).toBe(true);
+  });
 });

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,4 @@
 @import "./components/ActionButton/ActionButton.scss";
 @import "./components/Spinner/Spinner.scss";
+@import "./components/SearchBox/SearchBox.scss";
 @import "./components/MainTable/MainTable.scss";


### PR DESCRIPTION
## Done
- SearchBox can now be given loading prop that shows a spinner

## QA
- Check the demo looks okay. You can add `loading` to the externallyControlled story to see that the spinner looks good with the clear button as well.

Fixes #112