### PR TITLE
Add prop to pass the selected value to the parent for the Select 

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -18,6 +18,7 @@ const Select = ({
   help,
   id,
   label,
+  onChange,
   options,
   required,
   stacked,
@@ -34,13 +35,12 @@ const Select = ({
       label={label}
       required={required}
       stacked={stacked}
-      success={success}
-    >
+      success={success}>
       <select
         className={classNames("p-form-validation__input", className)}
         id={id}
-        {...props}
-      >
+        onChange={evt => onChange(evt.target.value)}
+        {...props}>
         {generateOptions(options)}
       </select>
     </Field>
@@ -54,6 +54,7 @@ Select.propTypes = {
   help: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
+  onChange: PropTypes.func,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -39,7 +39,7 @@ const Select = ({
       <select
         className={classNames("p-form-validation__input", className)}
         id={id}
-        onChange={evt => onChange(evt.target.value)}
+        onChange={(evt) => onChange && onChange(evt)}
         {...props}>
         {generateOptions(options)}
       </select>

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs } from "@storybook/addon-knobs";
+import { useState } from "react";
 import Select from "./Select";
 
 <Meta title="Select" component={Select} decorators={[withKnobs]} />
@@ -18,18 +19,24 @@ Use the Select component to create a drop-down list.
 
 <Preview>
   <Story name="Select">
-    <Select
-      name="exampleSelect"
-      id="exampleSelect2"
-      defaultValue=""
-      options={[
-        { value: "", disabled: "disabled", label: "Select an option" },
-        { value: "1", label: "Cosmic Cuttlefish" },
-        { value: "2", label: "Bionic Beaver" },
-        { value: "3", label: "Xenial Xerus" }
-      ]}
-      label="Ubuntu releases"
-    />
+    {() => {
+      const [selectedValue, setSelectedValue] = useState();
+      return (
+        <Select
+          name="exampleSelect"
+          id="exampleSelect2"
+          defaultValue=""
+          options={[
+            { value: "", disabled: "disabled", label: "Select an option" },
+            { value: "1", label: "Cosmic Cuttlefish" },
+            { value: "2", label: "Bionic Beaver" },
+            { value: "3", label: "Xenial Xerus" }
+          ]}
+          label="Ubuntu releases"
+          onChange={(selected) => setSelectedValue(selected)}
+        />
+      );
+    }}
   </Story>
 </Preview>
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -7,16 +7,32 @@ describe("Select ", () => {
   it("renders", () => {
     const wrapper = shallow(
       <Select
-        id="test-id"
+        id='test-id'
         options={[
           { value: "", disabled: "disabled", label: "Select an option" },
           { value: "1", label: "Cosmic Cuttlefish" },
           { value: "2", label: "Bionic Beaver" },
-          { value: "3", label: "Xenial Xerus" }
+          { value: "3", label: "Xenial Xerus" },
         ]}
       />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call onChange prop", () => {
+    const onChangeMock = jest.fn();
+    const event = {
+      preventDefault() {},
+      target: { value: "test-value" },
+    };
+    const component = shallow(
+      <Select
+        options={[]}
+        onChange={onChangeMock}
+      />
+    );
+    component.find("select").simulate("change", event);
+    expect(onChangeMock).toBeCalledWith("test-value");
   });
 
   it("can add additional classes", () => {

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -7,7 +7,7 @@ describe("Select ", () => {
   it("renders", () => {
     const wrapper = shallow(
       <Select
-        id='test-id'
+        id="test-id"
         options={[
           { value: "", disabled: "disabled", label: "Select an option" },
           { value: "1", label: "Cosmic Cuttlefish" },
@@ -22,8 +22,7 @@ describe("Select ", () => {
   it("should call onChange prop", () => {
     const onChangeMock = jest.fn();
     const event = {
-      preventDefault() {},
-      target: { value: "test-value" },
+      event: "test-event"
     };
     const component = shallow(
       <Select
@@ -32,7 +31,7 @@ describe("Select ", () => {
       />
     );
     component.find("select").simulate("change", event);
-    expect(onChangeMock).toBeCalledWith("test-value");
+    expect(onChangeMock).toBeCalledWith(event);
   });
 
   it("can add additional classes", () => {

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -8,6 +8,7 @@ exports[`Select  renders 1`] = `
   <select
     className="p-form-validation__input"
     id="test-id"
+    onChange={[Function]}
   >
     <option
       disabled="disabled"


### PR DESCRIPTION
## Done

- Add prop to pass the selected value to the parent for the Select component

## QA 

- Go to `/?path=/docs/select--select` and see the new prop of the `Select` component
- See the state of the parent component is updated with the `value` of the selected option when the selection is changed