### PR TITLE
Migrate Tabs component from maas-ui.

### DIFF
--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,0 +1,82 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Tabs = ({ className, links, listClassName }) => {
+  return (
+    <nav className={classNames("p-tabs", className)}>
+      <ul className={classNames("p-tabs__list", listClassName)}>
+        {links.map((link) => {
+          const {
+            active,
+            className,
+            component,
+            label,
+            listItemClassName,
+            ...rest
+          } = link;
+          const Component = component || "a";
+          return (
+            <li
+              className={classNames("p-tabs__item", listItemClassName)}
+              key={label}
+            >
+              <Component
+                aria-selected={active}
+                className={classNames("p-tabs__link", className)}
+                data-test={`tab-link-${label}`}
+                {...rest}
+              >
+                {label}
+              </Component>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+Tabs.propTypes = {
+  /**
+   * Optional classes applied to the parent "nav" element.
+   */
+  className: PropTypes.string,
+  /**
+   * An array of tab link objects.
+   */
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Whether the tab link should have active styling.
+       */
+      active: PropTypes.bool,
+      /**
+       * Optional classes applied to the link element.
+       */
+      className: PropTypes.string,
+      /**
+       * Optional component to be used instead of the default "a" element.
+       */
+      component: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.node,
+        PropTypes.object,
+      ]),
+      /**
+       * Label to be displayed inside the tab link.
+       */
+      label: PropTypes.node.isRequired,
+      /**
+       * Optional classes applied to the "li" element.
+       */
+      listItemClassName: PropTypes.string,
+    }).isRequired
+  ),
+  /**
+   * Optional classes applied to the "ul" element.
+   */
+  listClassName: PropTypes.string,
+};
+
+export default Tabs;

--- a/src/components/Tabs/Tabs.stories.mdx
+++ b/src/components/Tabs/Tabs.stories.mdx
@@ -1,0 +1,71 @@
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { boolean, withKnobs } from "@storybook/addon-knobs";
+import Row from "../Row";
+import Tabs from "./Tabs";
+
+<Meta title="Tabs" component={Tabs} decorators={[withKnobs]} />
+
+### Tabs
+
+This is the [React](https://reactjs.org/) component for Vanilla [Tabs](https://vanillaframework.io/docs/patterns/tabs).
+
+Tabs organise and allow navigation between groups of content that are related and at the same level
+of hierarchy.
+
+### Props
+
+<Props of={Tabs} />
+
+### Default
+
+<Preview>
+  <Story name="Default">
+    <Tabs
+      links={[
+        {
+          active: boolean("Summary active", true),
+          label: "Summary",
+        }, {
+          active: boolean("Network active", false),
+          label: "Network",
+        }, {
+          active: boolean("Storage active", false),
+          label: "Storage",
+        }, {
+          active: boolean("Settings active", false),
+          label: "Settings",
+        }
+      ]}
+    />
+  </Story>
+</Preview>
+
+### Horizontally aligned
+
+To horizontally align the Tabs with other content, they can be contained within a Row component to
+provide correct gutters.
+
+<Preview>
+  <Story name="Horizontally aligned">
+    <Row>
+      <Tabs
+        links={[
+          {
+            active: boolean("Summary active", true),
+            label: "Summary",
+          }, {
+            active: boolean("Network active", false),
+            label: "Network",
+          }, {
+            active: boolean("Storage active", false),
+            label: "Storage",
+          }, {
+            active: boolean("Settings active", false),
+            label: "Settings",
+          }
+        ]}
+      />
+      <p>There should be gutters and the text should be horizontally aligned</p>
+    </Row>
+  </Story>
+</Preview>

--- a/src/components/Tabs/Tabs.test.js
+++ b/src/components/Tabs/Tabs.test.js
@@ -1,0 +1,102 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Tabs from "./Tabs";
+
+describe("Tabs", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Tabs
+        links={[
+          {
+            active: true,
+            href: "/path1",
+            label: "label1",
+          },
+          {
+            active: false,
+            href: "/path2",
+            label: "label2",
+          },
+        ]}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("sets an active item correctly", () => {
+    const wrapper = shallow(
+      <Tabs
+        links={[
+          {
+            active: true,
+            label: "label1",
+          },
+          {
+            active: false,
+            label: "label2",
+          },
+        ]}
+      />
+    );
+    expect(wrapper.find("[aria-selected=true]").length).toBe(1);
+  });
+
+  it("can set classNames correctly", () => {
+    const wrapper = shallow(
+      <Tabs
+        className="nav-class"
+        listClassName="list-class"
+        links={[
+          {
+            className: "link-class",
+            label: "label1",
+            listItemClassName: "list-item-class",
+          },
+        ]}
+      />
+    );
+    expect(
+      wrapper
+        .find("nav")
+        .props()
+        .className.includes("nav-class")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("ul")
+        .props()
+        .className.includes("list-class")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("li")
+        .props()
+        .className.includes("list-item-class")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("a")
+        .props()
+        .className.includes("link-class")
+    ).toBe(true);
+  });
+
+  it("can set custom components as links", () => {
+    const wrapper = shallow(
+      <Tabs
+        links={[
+          {
+            component: "div",
+            label: "label1",
+            to: "/path",
+          },
+        ]}
+      />
+    );
+    expect(wrapper.find("a[data-test='tab-link-label1']").exists()).toBe(false);
+    expect(wrapper.find("div[data-test='tab-link-label1']").exists()).toBe(
+      true
+    );
+  });
+});

--- a/src/components/Tabs/__snapshots__/Tabs.test.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tabs renders 1`] = `
+<nav
+  className="p-tabs"
+>
+  <ul
+    className="p-tabs__list"
+  >
+    <li
+      className="p-tabs__item"
+      key="label1"
+    >
+      <a
+        aria-selected={true}
+        className="p-tabs__link"
+        data-test="tab-link-label1"
+        href="/path1"
+      >
+        label1
+      </a>
+    </li>
+    <li
+      className="p-tabs__item"
+      key="label2"
+    >
+      <a
+        aria-selected={false}
+        className="p-tabs__link"
+        data-test="tab-link-label2"
+        href="/path2"
+      >
+        label2
+      </a>
+    </li>
+  </ul>
+</nav>
+`;

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Tabs";


### PR DESCRIPTION
## Done
- Migrated [Tabs component from maas-ui](https://github.com/canonical-web-and-design/maas-ui/tree/master/ui/src/app/base/components/Tabs) with some modifications to make it more generic
  - You can now give links a `component` prop in cases where you might want normal anchor links or react-router links
  - Removed the `noBorder` prop - that's not in Vanilla and should just be handled by `listClassName` anyway

## QA
- Run `yarn docs` and check that the canvas and docs for Tabs are good

Fixes #150 