### PR TITLE
Migrate Tooltip component from maas-ui.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "prop-types": "15.7.2",
+    "react-useportal": "1.0.13",
     "vanilla-framework": "2.13.0"
   },
   "peerDependencies": {

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,0 +1,113 @@
+import PropTypes from "prop-types";
+import React, { useRef } from "react";
+import usePortal from "react-useportal";
+
+const getPositionStyle = (position, el) => {
+  if (!el || !el.current) {
+    return undefined;
+  }
+
+  const dimensions = el.current.getBoundingClientRect();
+  const { x, y, height, width } = dimensions;
+  let left = x + window.scrollX || 0;
+  let top = y + window.scrollY || 0;
+
+  switch (position) {
+    case "btm-center":
+      left += width / 2;
+      top += height;
+      break;
+    case "btm-left":
+      top += height;
+      break;
+    case "btm-right":
+      left += width;
+      top += height;
+      break;
+    case "left":
+      top += height / 2;
+      break;
+    case "right":
+      left += width;
+      top += height / 2;
+      break;
+    case "top-center":
+      left += width / 2;
+      break;
+    case "top-left":
+      break;
+    case "top-right":
+      left += width;
+      break;
+    default:
+      break;
+  }
+
+  return { position: "absolute", left, top };
+};
+
+const Tooltip = ({ children, message, position = "top-left" }) => {
+  const el = useRef(null);
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const positionStyle = getPositionStyle(position, el);
+
+  return (
+    <>
+      {message ? (
+        <span
+          onBlur={closePortal}
+          onFocus={openPortal}
+          onMouseOut={closePortal}
+          onMouseOver={openPortal}
+          ref={el}
+        >
+          {children}
+          {isOpen && (
+            <Portal>
+              <span
+                className={`p-tooltip--${position}`}
+                data-test="tooltip-portal"
+                style={positionStyle}
+              >
+                <span
+                  className="p-tooltip__message"
+                  style={{ display: "inline" }}
+                >
+                  {message}
+                </span>
+              </span>
+            </Portal>
+          )}
+        </span>
+      ) : (
+        children
+      )}
+    </>
+  );
+};
+
+Tooltip.propTypes = {
+  /**
+   * Element on which to apply the tooltip.
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Message to display when the element is hovered.
+   */
+  message: PropTypes.node,
+  /**
+   * Position of the tooltip relative to the element.
+   */
+  position: PropTypes.oneOf([
+    "btm-center",
+    "btm-left",
+    "btm-right",
+    "left",
+    "right",
+    "top-center",
+    "top-left",
+    "top-right",
+  ]),
+};
+
+export default Tooltip;

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -1,0 +1,47 @@
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { select, withKnobs } from "@storybook/addon-knobs";
+import Button from "../Button";
+import Tooltip from "./Tooltip";
+
+<Meta title="Tooltip" component={Tooltip} decorators={[withKnobs]} />
+
+### Tooltip
+
+This is the [React](https://reactjs.org/) component for Vanilla [Tooltips](https://vanillaframework.io/docs/patterns/tooltips).
+
+Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen.
+
+They can be used to provide information about concepts/terms/actions that are not self-explanatory or well known.
+
+An alternative use of tooltips is to provide information on a disabled actionable element, e.g. for disabled buttons, providing information about why they are disabled.
+
+### Props
+
+<Props of={Tooltip} />
+
+### Default
+
+<Preview>
+  <Story name="Default">
+    <div style={{ display: "flex", justifyContent: "center", padding: "3rem" }}>
+      <Tooltip
+        message="Tooltip message to display."
+        position={select(
+          "Position",
+          [
+            "top-left",
+            "top-center",
+            "top-right",
+            "left",
+            "right",
+            "btm-left",
+            "btm-center",
+            "btm-right"
+          ],
+        )}
+      >
+        <Button className="u-no-margin--bottom">Hover over me!</Button>
+      </Tooltip>
+    </div>
+  </Story>
+</Preview>

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -1,0 +1,41 @@
+import { mount, shallow } from "enzyme";
+import React from "react";
+
+import Tooltip from "./Tooltip";
+
+describe("<Tooltip />", () => {
+  const body = document.querySelector("body");
+  const app = document.createElement("div");
+  app.setAttribute("id", "app");
+  body.appendChild(app);
+
+  // snapshot tests
+  it("renders and matches the snapshot", () => {
+    const component = shallow(<Tooltip message="text">Child</Tooltip>);
+    expect(component).toMatchSnapshot();
+  });
+
+  // unit tests
+  it("does not show tooltip message by default", () => {
+    const component = mount(<Tooltip message="text">Child</Tooltip>);
+    expect(component.exists("[data-test='tooltip-portal']")).toEqual(false);
+  });
+
+  it("renders tooltip message when focused", () => {
+    const component = mount(<Tooltip message="text">Child</Tooltip>);
+    component.simulate("focus");
+    expect(component.find("[data-test='tooltip-portal']").text()).toEqual(
+      "text"
+    );
+  });
+
+  it("gives the correct class name to the tooltip", () => {
+    const component = mount(
+      <Tooltip message="text" position="right">
+        Child
+      </Tooltip>
+    );
+    component.simulate("focus");
+    expect(component.exists(".p-tooltip--right")).toEqual(true);
+  });
+});

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tooltip /> renders and matches the snapshot 1`] = `
+<Fragment>
+  <span
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+  >
+    Child
+  </span>
+</Fragment>
+`;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Tooltip";

--- a/yarn.lock
+++ b/yarn.lock
@@ -14129,6 +14129,13 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
+react-useportal@1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.13.tgz#abfc29f8128756cd7382bff7c81a4f446b792199"
+  integrity sha512-83KpNTXUIHnRVTLeMberIblCtssvRSKCPnG/xT9NW60gDYfU13pQBNQKCVUF8MBK+7LnCQ/ZrOuXl8Mp+iXdXA==
+  dependencies:
+    use-ssr "^1.0.19"
+
 react@^16.8.3:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
@@ -16737,6 +16744,11 @@ use-sidecar@^1.0.1:
   dependencies:
     detect-node "^2.0.4"
     tslib "^1.9.3"
+
+use-ssr@^1.0.19:
+  version "1.0.23"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.23.tgz#3bde1e10cd01b3b61ab6386d7cddb72e74828bf8"
+  integrity sha512-5bvlssgROgPgIrnILJe2mJch4e2Id0/bVm1SQzqvPvEAXmlsinCCVHWK3a2iHcPat7PkdJHBo0gmSmODIz6tNA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Done
- Migrated [Tooltip component from maas-ui](https://github.com/canonical-web-and-design/maas-ui/tree/master/ui/src/app/base/components/Tooltip) with one modification to remove the custom `p-tooltip__message--portal` class and use an inline style instead.
- Added `react-useportal` dependency.

## QA
- Run `yarn docs` and check that there is a Tooltip page.
- Check that you can change the position property on the canvas.
- Check that the props are documented.

Fixes #151 