### PR TITLE
Add `titleElement` prop to accordion to support headings in titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `titleElement` prop to Accordion component to allow rendering title headings for accordion tabs.
+
 ### Changed
 
 ### Removed

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -4,13 +4,14 @@ import React, { useState } from "react";
 
 import AccordionSection from "../AccordionSection";
 
-const generateSections = (sections, setExpanded, expanded) =>
+const generateSections = (sections, setExpanded, expanded, titleElement) =>
   sections.map(({ key, ...props }, i) => (
     <AccordionSection
       expanded={expanded}
       key={key || i}
       sectionKey={key}
       setExpanded={setExpanded}
+      titleElement={titleElement}
       {...props}
     />
   ));
@@ -21,6 +22,7 @@ const Accordion = ({
   externallyControlled,
   onExpandedChange,
   sections,
+  titleElement,
   ...props
 }) => {
   const [expandedSection, setExpandedSection] = useState(expanded);
@@ -39,7 +41,8 @@ const Accordion = ({
         {generateSections(
           sections,
           setExpanded,
-          externallyControlled ? expanded : expandedSection
+          externallyControlled ? expanded : expandedSection,
+          titleElement
         )}
       </ul>
     </aside>
@@ -89,7 +92,11 @@ Accordion.propTypes = {
    * Optional function that is called when the expanded section is changed.
    * The function is provided the section title or null.
    */
-  onExpandedChange: PropTypes.func
+  onExpandedChange: PropTypes.func,
+  /**
+    * Optional string describing heading element that should be used for the secion titles.
+    */
+  titleElement: PropTypes.oneOf(["h2", "h3", "h4", "h5", "h6"])
 };
 
 export default Accordion;

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -119,3 +119,53 @@ The expanded accordion section can be controlled by external state.
     }}
   </Story>
 </Preview>
+
+
+### Headings
+
+`titleElement` prop can be used to define heading element for section titles.
+
+<Preview>
+  <Story name="Headings">
+    <Accordion
+      sections={[
+        {
+          title: "Advanced topics",
+          content: (
+            <>
+              <p>Charm bundles</p>
+              <p>Machine authentication</p>
+              <p>Migrating models</p>
+              <p>Using storage</p>
+              <p>Working with actions</p>
+              <p>Working with resources</p>
+              <p>Cloud image metadata</p>
+              <p>Tools</p>
+            </>
+          )
+        },
+        {
+          title: "Networking",
+          content: (
+            <>
+              <p>Working offline</p>
+              <p>Fan container networking</p>
+              <p>Network spaces</p>
+            </>
+          )
+        },
+        {
+          title: "Miscellaneous",
+          content: (
+            <>
+              <p>Juju GUI</p>
+              <p>CentOS support</p>
+              <p>Collecting Juju metrics</p>
+            </>
+          )
+        }
+      ]}
+      titleElement="h3"
+    />
+  </Story>
+</Preview>

--- a/src/components/Accordion/Accordion.test.js
+++ b/src/components/Accordion/Accordion.test.js
@@ -26,6 +26,25 @@ describe("Accordion ", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("renders headings for titles", () => {
+    const wrapper = shallow(
+      <Accordion
+        sections={[
+          {
+            title: "Advanced topics",
+            content: "test content"
+          },
+          {
+            title: "Networking",
+            content: <>More test content</>
+          }
+        ]}
+        titleElement="h4"
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("can call a function when a section is expanded", () => {
     const onExpandedChange = jest.fn();
     const wrapper = mount(

--- a/src/components/Accordion/Accordion.test.js
+++ b/src/components/Accordion/Accordion.test.js
@@ -26,7 +26,7 @@ describe("Accordion ", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("renders headings for titles", () => {
+  it("passes title heading element to AccordionSections", () => {
     const wrapper = shallow(
       <Accordion
         sections={[
@@ -42,7 +42,12 @@ describe("Accordion ", () => {
         titleElement="h4"
       />
     );
-    expect(wrapper).toMatchSnapshot();
+    expect(
+      wrapper
+        .find("AccordionSection")
+        .at(0)
+        .prop("titleElement")
+    ).toBe("h4");
   });
 
   it("can call a function when a section is expanded", () => {

--- a/src/components/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.js.snap
@@ -28,3 +28,34 @@ exports[`Accordion  renders 1`] = `
   </ul>
 </aside>
 `;
+
+exports[`Accordion  renders headings for titles 1`] = `
+<aside
+  aria-multiselectable="true"
+  className="p-accordion"
+  role="tablist"
+>
+  <ul
+    className="p-accordion__list"
+  >
+    <AccordionSection
+      content="test content"
+      key="0"
+      setExpanded={[Function]}
+      title="Advanced topics"
+      titleElement="h4"
+    />
+    <AccordionSection
+      content={
+        <React.Fragment>
+          More test content
+        </React.Fragment>
+      }
+      key="1"
+      setExpanded={[Function]}
+      title="Networking"
+      titleElement="h4"
+    />
+  </ul>
+</aside>
+`;

--- a/src/components/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.js.snap
@@ -28,34 +28,3 @@ exports[`Accordion  renders 1`] = `
   </ul>
 </aside>
 `;
-
-exports[`Accordion  renders headings for titles 1`] = `
-<aside
-  aria-multiselectable="true"
-  className="p-accordion"
-  role="tablist"
->
-  <ul
-    className="p-accordion__list"
-  >
-    <AccordionSection
-      content="test content"
-      key="0"
-      setExpanded={[Function]}
-      title="Advanced topics"
-      titleElement="h4"
-    />
-    <AccordionSection
-      content={
-        <React.Fragment>
-          More test content
-        </React.Fragment>
-      }
-      key="1"
-      setExpanded={[Function]}
-      title="Networking"
-      titleElement="h4"
-    />
-  </ul>
-</aside>
-`;

--- a/src/components/AccordionSection/AccordionSection.js
+++ b/src/components/AccordionSection/AccordionSection.js
@@ -8,17 +8,21 @@ const AccordionSection = ({
   onTitleClick,
   sectionKey,
   setExpanded,
-  title
+  title,
+  titleElement
 }) => {
   const sectionId = useRef(uuidv4());
   const key = sectionKey || sectionId.current;
   const isExpanded = expanded === key;
+  const Title = titleElement || null;
+  const hasTitleElement = !!Title;
+
   return (
     <li className="p-accordion__group">
       <button
         aria-controls={`#${sectionId.current}`}
         aria-expanded={isExpanded ? "true" : "false"}
-        className="p-accordion__tab"
+        className={hasTitleElement ? "p-accordion__tab--with-title" : "p-accordion__tab"}
         onClick={() => {
           if (isExpanded) {
             setExpanded(null, null);
@@ -30,7 +34,7 @@ const AccordionSection = ({
         role="tab"
         type="button"
       >
-        {title}
+        {hasTitleElement ? <Title className="p-accordion__title">{title}</Title> : title}
       </button>
       <section
         aria-hidden={isExpanded ? "false" : "true"}
@@ -57,7 +61,8 @@ AccordionSection.propTypes = {
    */
   sectionKey: PropTypes.string,
   setExpanded: PropTypes.func,
-  title: PropTypes.string
+  title: PropTypes.string,
+  titleElement: PropTypes.oneOf(["h2", "h3", "h4", "h5", "h6"])
 };
 
 export default AccordionSection;

--- a/src/components/AccordionSection/AccordionSection.test.js
+++ b/src/components/AccordionSection/AccordionSection.test.js
@@ -30,6 +30,7 @@ describe("AccordionSection ", () => {
         titleElement="h4"
       />
     );
+    expect(wrapper.find('h4.p-accordion__title')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/components/AccordionSection/AccordionSection.test.js
+++ b/src/components/AccordionSection/AccordionSection.test.js
@@ -20,6 +20,19 @@ describe("AccordionSection ", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("renders headings for titles", () => {
+    const wrapper = shallow(
+      <AccordionSection
+        content={<span>Test</span>}
+        expanded="abcd-1234"
+        setExpanded={jest.fn()}
+        title="Test section"
+        titleElement="h4"
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("can handle click events on the title", () => {
     const onTitleClick = jest.fn();
     let expanded = null;

--- a/src/components/AccordionSection/__snapshots__/AccordionSection.test.js.snap
+++ b/src/components/AccordionSection/__snapshots__/AccordionSection.test.js.snap
@@ -27,3 +27,35 @@ exports[`AccordionSection  renders 1`] = `
   </section>
 </li>
 `;
+
+exports[`AccordionSection  renders headings for titles 1`] = `
+<li
+  className="p-accordion__group"
+>
+  <button
+    aria-controls="#00000000-0000-0000-0000-000000000000"
+    aria-expanded="false"
+    className="p-accordion__tab--with-title"
+    onClick={[Function]}
+    role="tab"
+    type="button"
+  >
+    <h4
+      className="p-accordion__title"
+    >
+      Test section
+    </h4>
+  </button>
+  <section
+    aria-hidden="true"
+    aria-labelledby="00000000-0000-0000-0000-000000000000"
+    className="p-accordion__panel"
+    id="00000000-0000-0000-0000-000000000000"
+    role="tabpanel"
+  >
+    <span>
+      Test
+    </span>
+  </section>
+</li>
+`;


### PR DESCRIPTION
Vanilla 2.13 added an option to use headings in accordion titles.
This PR adds `titleElement` prop to the `Accordion` (and `AccordionSection`) components to enable this.

<img width="1068" alt="Screenshot 2020-06-17 at 15 12 46" src="https://user-images.githubusercontent.com/83575/84902376-0b155680-b0ad-11ea-996b-1c4d67956f0b.png">
