### PR TITLE
Add lead-value chip

### DIFF
--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -3,17 +3,11 @@ import PropTypes from "prop-types";
 
 import "./Chip.scss";
 
-const generateLead = (lead) => {
-  if (!lead && typeof lead !== "string") {
-    return "";
-  }
-  return `${lead.toUpperCase()}: `;
-}
-
-const Chip = ({ value, lead }) => {
+const Chip = ({ value, lead = "" }) => {
   return (
     <div className="p-chip">
-      { generateLead(lead) }{ value }
+      {lead ? `${lead.toUpperCase()}: ` : null}
+      {value}
     </div>
   );
 };

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -3,16 +3,24 @@ import PropTypes from "prop-types";
 
 import "./Chip.scss";
 
-const Chip = ({ value }) => {
+const generateLead = (lead) => {
+  if (!lead && typeof lead !== "string") {
+    return "";
+  }
+  return `${lead.toUpperCase()}: `;
+}
+
+const Chip = ({ value, lead }) => {
   return (
     <div className="p-chip">
-      { value }
+      { generateLead(lead) }{ value }
     </div>
   );
 };
 
 Chip.propTypes = {
   value: PropTypes.string,
+  lead: PropTypes.string,
 };
 
 export default Chip;

--- a/src/components/Chip/Chip.stories.mdx
+++ b/src/components/Chip/Chip.stories.mdx
@@ -19,3 +19,11 @@ This is a not an existing Vanilla component. It can be used to display a small v
     <Chip value="positive"></Chip>
   </Story>
 </Preview>
+
+### Key-value
+
+<Preview>
+  <Story name="Lead-value">
+    <Chip lead="Owner" value="Bob"></Chip>
+  </Story>
+</Preview>

--- a/src/components/Chip/Chip.test.js
+++ b/src/components/Chip/Chip.test.js
@@ -4,13 +4,23 @@ import React from "react";
 import Chip from "./Chip";
 
 describe("Chip ", () => {
-  it("renders", () => {
+  it("renders default chip", () => {
     const wrapper = shallow(<Chip value="positive" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders lead-value chip", () => {
+    const wrapper = shallow(<Chip lead="Owner" value="Bob" />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("displays the value", () => {
     const wrapper = mount(<Chip value="positive" />);
     expect(wrapper.find(".p-chip").text()).toBe("positive");
+  });
+
+  it("displays the lead-value", () => {
+    const wrapper = mount(<Chip lead="Owner" value="Bob" />);
+    expect(wrapper.find(".p-chip").text()).toBe("OWNER: Bob");
   });
 });

--- a/src/components/Chip/__snapshots__/Chip.test.js.snap
+++ b/src/components/Chip/__snapshots__/Chip.test.js.snap
@@ -1,9 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Chip  renders 1`] = `
+exports[`Chip  renders default chip 1`] = `
 <div
   className="p-chip"
 >
   positive
+</div>
+`;
+
+exports[`Chip  renders lead-value chip 1`] = `
+<div
+  className="p-chip"
+>
+  OWNER: 
+  Bob
 </div>
 `;


### PR DESCRIPTION
## Done
Added lead prop to chip to render lead-value chips.
*I switched from key-value as key it a reserved prop*

## QA
- Run `./run`
- Go to http://localhost:8403/?path=/story/chip--lead-value
- Check it looks like [the design](https://app.zeplin.io/project/5ed19809e42d2c9b901fcd9c/screen/5ed19897d3b87fb8faba02e4) _excluding the X action_

Fixes: https://github.com/canonical-web-and-design/juju-squad/issues/1334