### PR TITLE
Add basic filter panel to Search and Filter component

### DIFF
--- a/src/components/SearchAndFilter/SearchAndFilter.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.js
@@ -1,10 +1,15 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
 import SearchBox from "../SearchBox";
+import ContextualMenu from "../ContextualMenu";
+
+import "./SearchAndFilter.scss";
 
 const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
   const [searchTerm, setSearchTerm] = useState("");
+  const [filterPanelVisible, setFilterPanelVisible] = useState(false);
+  const filterPanelRef = useRef();
 
   const searchOnChange = (searchTerm) => {
     setSearchTerm(searchTerm);
@@ -13,14 +18,56 @@ const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
     }
   };
 
+  // This useEffect sets up listeners so the panel will close if user clicks
+  // anywhere else on the page or hits the escape key
+  useEffect(() => {
+    const closePanel = () => {
+      setFilterPanelVisible(false);
+    };
+
+    const mouseDown = (e) => {
+      // Check if click is outside of filter panel
+      if (!filterPanelRef.current.contains(e.target)) {
+        // If so, close the panel
+        closePanel();
+      }
+    };
+
+    const keyDown = (e) => {
+      if (e.code === "Escape") {
+        // Close panel if Esc keydown detected
+        closePanel();
+      }
+    };
+
+    // Add listener on document to capture click events
+    document.addEventListener("mousedown", mouseDown);
+    // Add listener on document to capture keydown events
+    document.addEventListener("keydown", keyDown);
+    // return function to be called when unmounted
+    return () => {
+      document.removeEventListener("mousedown", mouseDown);
+      document.removeEventListener("keydown", keyDown);
+    };
+  }, []);
+
   return (
     <div className="search-and-filter">
       <SearchBox
+        autocomplete="off"
         externallyControlled={externallyControlled}
         placeholder="Search and filter"
         onChange={(searchTerm) => searchOnChange(searchTerm)}
+        onFocus={() => setFilterPanelVisible(true)}
         value={searchTerm}
       />
+      <div
+        className="search-and-filter__panel"
+        ref={filterPanelRef}
+        data-visible={filterPanelVisible}
+      >
+        <ContextualMenu>Filter panel content</ContextualMenu>
+      </div>
     </div>
   );
 };

--- a/src/components/SearchAndFilter/SearchAndFilter.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.js
@@ -8,7 +8,7 @@ import "./SearchAndFilter.scss";
 
 const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [filterPanelVisible, setFilterPanelVisible] = useState(false);
+  const [filterPanelHidden, setFilterPanelHidden] = useState(true);
   const filterPanelRef = useRef();
 
   const searchOnChange = (searchTerm) => {
@@ -22,7 +22,7 @@ const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
   // anywhere else on the page or hits the escape key
   useEffect(() => {
     const closePanel = () => {
-      setFilterPanelVisible(false);
+      setFilterPanelHidden(true);
     };
 
     const mouseDown = (e) => {
@@ -58,13 +58,13 @@ const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
         externallyControlled={externallyControlled}
         placeholder="Search and filter"
         onChange={(searchTerm) => searchOnChange(searchTerm)}
-        onFocus={() => setFilterPanelVisible(true)}
+        onFocus={() => setFilterPanelHidden(false)}
         value={searchTerm}
       />
       <div
         className="search-and-filter__panel"
         ref={filterPanelRef}
-        data-visible={filterPanelVisible}
+        aria-hidden={filterPanelHidden}
       >
         <ContextualMenu>Filter panel content</ContextualMenu>
       </div>

--- a/src/components/SearchAndFilter/SearchAndFilter.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.js
@@ -58,6 +58,7 @@ const SearchAndFilter = ({ externallyControlled = false, onChange }) => {
         externallyControlled={externallyControlled}
         placeholder="Search and filter"
         onChange={(searchTerm) => searchOnChange(searchTerm)}
+        onClick={() => setFilterPanelHidden(false)}
         onFocus={() => setFilterPanelHidden(false)}
         value={searchTerm}
       />

--- a/src/components/SearchAndFilter/SearchAndFilter.scss
+++ b/src/components/SearchAndFilter/SearchAndFilter.scss
@@ -25,7 +25,7 @@
     padding: 0;
     transition: opacity 0.25s;
 
-    &[data-visible="false"] {
+    &[aria-hidden="true"] {
       opacity: 0;
       pointer-events: none;
     }

--- a/src/components/SearchAndFilter/SearchAndFilter.scss
+++ b/src/components/SearchAndFilter/SearchAndFilter.scss
@@ -1,6 +1,4 @@
 .search-and-filter {
-  position: relative;
-
   span[class*="p-contextual-menu"],
   .p-contextual-menu__dropdown {
     display: block;

--- a/src/components/SearchAndFilter/SearchAndFilter.scss
+++ b/src/components/SearchAndFilter/SearchAndFilter.scss
@@ -1,0 +1,33 @@
+.search-and-filter {
+  position: relative;
+
+  span[class*="p-contextual-menu"],
+  .p-contextual-menu__dropdown {
+    display: block;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .p-contextual-menu__dropdown {
+    padding: 0.5rem;
+  }
+
+  .p-search-box {
+    margin: 0;
+  }
+
+  .p-contextual-menu__dropdown {
+    top: 0;
+    left: 0;
+  }
+
+  &__panel {
+    padding: 0;
+    transition: opacity 0.25s;
+
+    &[data-visible="false"] {
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
+}

--- a/src/components/SearchAndFilter/SearchAndFilter.test.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.js
@@ -3,7 +3,7 @@ import React from "react";
 
 import SearchAndFilter from "./SearchAndFilter";
 
-describe("Search and filter ", () => {
+describe("Search and filter", () => {
   it("renders", () => {
     const wrapper = shallow(<SearchAndFilter />);
     expect(wrapper).toMatchSnapshot();
@@ -21,5 +21,19 @@ describe("Search and filter ", () => {
     );
     wrapper.find(".p-search-box__input").simulate("change");
     expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows panel on focus", () => {
+    const mockOnChange = jest.fn();
+    const wrapper = mount(
+      <SearchAndFilter externallyControlled onChange={mockOnChange} />
+    );
+    expect(
+      wrapper.find(".search-and-filter__panel").prop("data-visible")
+    ).toEqual(false);
+    wrapper.find(".p-search-box__input").simulate("focus");
+    expect(
+      wrapper.find(".search-and-filter__panel").prop("data-visible")
+    ).toEqual(true);
   });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.test.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.js
@@ -36,4 +36,18 @@ describe("Search and filter", () => {
       wrapper.find(".search-and-filter__panel").prop("aria-hidden")
     ).toEqual(false);
   });
+
+  it("shows panel on click", () => {
+    const mockOnChange = jest.fn();
+    const wrapper = mount(
+      <SearchAndFilter externallyControlled onChange={mockOnChange} />
+    );
+    expect(
+      wrapper.find(".search-and-filter__panel").prop("aria-hidden")
+    ).toEqual(true);
+    wrapper.find(".p-search-box__input").simulate("click");
+    expect(
+      wrapper.find(".search-and-filter__panel").prop("aria-hidden")
+    ).toEqual(false);
+  });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.test.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.js
@@ -29,11 +29,11 @@ describe("Search and filter", () => {
       <SearchAndFilter externallyControlled onChange={mockOnChange} />
     );
     expect(
-      wrapper.find(".search-and-filter__panel").prop("data-visible")
-    ).toEqual(false);
+      wrapper.find(".search-and-filter__panel").prop("aria-hidden")
+    ).toEqual(true);
     wrapper.find(".p-search-box__input").simulate("focus");
     expect(
-      wrapper.find(".search-and-filter__panel").prop("data-visible")
-    ).toEqual(true);
+      wrapper.find(".search-and-filter__panel").prop("aria-hidden")
+    ).toEqual(false);
   });
 });

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
@@ -13,8 +13,8 @@ exports[`Search and filter renders 1`] = `
     value=""
   />
   <div
+    aria-hidden={true}
     className="search-and-filter__panel"
-    data-visible={false}
   >
     <ContextualMenu>
       Filter panel content

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
@@ -1,14 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search and filter  renders 1`] = `
+exports[`Search and filter renders 1`] = `
 <div
   className="search-and-filter"
 >
   <SearchBox
+    autocomplete="off"
     externallyControlled={false}
     onChange={[Function]}
+    onFocus={[Function]}
     placeholder="Search and filter"
     value=""
   />
+  <div
+    className="search-and-filter__panel"
+    data-visible={false}
+  >
+    <ContextualMenu>
+      Filter panel content
+    </ContextualMenu>
+  </div>
 </div>
 `;

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
@@ -8,6 +8,7 @@ exports[`Search and filter renders 1`] = `
     autocomplete="off"
     externallyControlled={false}
     onChange={[Function]}
+    onClick={[Function]}
     onFocus={[Function]}
     placeholder="Search and filter"
     value=""

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const SearchBox = ({
+  autocomplete = "on",
   className,
   disabled,
   externallyControlled,
@@ -31,6 +32,7 @@ const SearchBox = ({
         {placeholder || "Search"}
       </label>
       <input
+        autoComplete={autocomplete}
         className="p-search-box__input"
         disabled={disabled}
         id="search"
@@ -66,6 +68,7 @@ const SearchBox = ({
 };
 
 SearchBox.propTypes = {
+  autocomplete: PropTypes.string,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/src/components/SearchBox/__snapshots__/SearchBox.test.js.snap
+++ b/src/components/SearchBox/__snapshots__/SearchBox.test.js.snap
@@ -12,6 +12,7 @@ exports[`SearchBox  renders 1`] = `
     Search
   </label>
   <input
+    autoComplete="on"
     className="p-search-box__input"
     id="search"
     name="search"

--- a/src/index.scss
+++ b/src/index.scss
@@ -2,3 +2,4 @@
 @import "./components/Spinner/Spinner.scss";
 @import "./components/MainTable/MainTable.scss";
 @import "./components/Chip/Chip.scss";
+@import "./components/SearchAndFilter/SearchAndFilter.scss";


### PR DESCRIPTION
## Done 

Add basic filter panel to Search and Filter component

## QA

- Fire up Storybook: http://localhost:65491/?path=/story/searchandfilter--default-story
- Click in input to activate panel
- Press Escape to close
- Click outside input or panel to close

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1335