### PR TITLE
Show overflow chips when counter is clicked

### DIFF
--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
@@ -7,6 +7,7 @@ import "./filter-panel-section.scss";
 const FilterPanelSection = ({ data }) => {
   const { chips, heading } = data;
   const [overflowCounter, setOverflowCounter] = useState(0);
+  const [expanded, setExpanded] = useState(false);
   const chipWrapper = useRef(null);
 
   // If the offsetTop is more than double height of a single chip, consider it
@@ -32,8 +33,12 @@ const FilterPanelSection = ({ data }) => {
     }
   }, []);
 
+  const showAllChips = () => {
+    setExpanded(true);
+  };
+
   return (
-    <div className="filter-panel-section">
+    <div className="filter-panel-section" aria-expanded={expanded}>
       {heading && (
         <h3 className="filter-panel-section__heading">{data.heading}</h3>
       )}
@@ -45,8 +50,13 @@ const FilterPanelSection = ({ data }) => {
             key={`${chip.lead}+${chip.value}`}
           />
         ))}
-        {overflowCounter > 0 && (
-          <span className="filter-panel-section__counter">
+        {overflowCounter > 0 && !expanded && (
+          <span
+            className="filter-panel-section__counter"
+            onClick={showAllChips}
+            onKeyPress={showAllChips}
+            tabIndex="0"
+          >
             +{overflowCounter}
           </span>
         )}

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
@@ -12,7 +12,7 @@ const FilterPanelSection = ({ data }) => {
   // If the offsetTop is more than double height of a single chip, consider it
   // overflowing
   const updateFlowCount = function () {
-    const chips = chipWrapper?.current.querySelectorAll(".p-chip");
+    const chips = chipWrapper?.current?.querySelectorAll(".p-chip");
     let overflowChips = 0;
     chips.forEach((chip) => {
       if (chip.offsetTop > chip.offsetHeight * 2) overflowChips++;

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
@@ -15,9 +15,11 @@ const FilterPanelSection = ({ data }) => {
   const updateFlowCount = function () {
     const chips = chipWrapper?.current?.querySelectorAll(".p-chip");
     let overflowChips = 0;
-    chips.forEach((chip) => {
-      if (chip.offsetTop > chip.offsetHeight * 2) overflowChips++;
-    });
+    if (chips) {
+      chips.forEach((chip) => {
+        if (chip.offsetTop > chip.offsetHeight * 2) overflowChips++;
+      });
+    }
     setOverflowCounter(overflowChips);
   };
 

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
@@ -56,4 +56,11 @@ describe("Filter panel section", () => {
     const wrapper = mount(<FilterPanelSection data={sampleData} />);
     expect(wrapper.find(".filter-panel-section__counter").text()).toEqual("+3");
   });
+
+  it("all chips are shown when counter is clicked", () => {
+    const wrapper = mount(<FilterPanelSection data={sampleData} />);
+    expect(wrapper.find("[aria-expanded=false]").length).toEqual(1);
+    wrapper.find(".filter-panel-section__counter").simulate("click");
+    expect(wrapper.find("[aria-expanded=true]").length).toEqual(1);
+  });
 });

--- a/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
+++ b/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Filter panel section renders 1`] = `
 <div
-  className="filter-panel-section"
   aria-expanded={false}
+  className="filter-panel-section"
 >
   <h3
     className="filter-panel-section__heading"

--- a/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
+++ b/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Filter panel section renders 1`] = `
 <div
   className="filter-panel-section"
+  aria-expanded={false}
 >
   <h3
     className="filter-panel-section__heading"

--- a/src/components/SearchAndFilter/FilterPanelSection/filter-panel-section.scss
+++ b/src/components/SearchAndFilter/FilterPanelSection/filter-panel-section.scss
@@ -20,9 +20,15 @@
     padding-right: 1.25rem;
     position: relative;
     max-height: 3.25rem;
+
+    [aria-expanded="true"] & {
+      overflow: visible;
+      max-height: 100%;
+    }
   }
 
   &__counter {
+    cursor: pointer;
     color: $color-information;
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
-Run Storybook
- View http://localhost:49435/iframe.html?id=searchandfilter--external-state
- Decrease screen size so overflow counter is shown
- Click overflow counter
- All chips should be shown
- Refresh page
- Navigate with keyboard, check counter can be activated with keyboard
