### PR TITLE
Allow a node to be passed to field help

### DIFF
--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -21,12 +21,12 @@ const generateError = (error, caution, success) => {
   );
 };
 
-const generateLabel = (forId, required, label, stacked) => {
+const generateLabel = (forId, required, label, labelClassName, stacked) => {
   if (!label) {
     return;
   }
   const labelNode = (
-    <Label forId={forId} required={required}>
+    <Label className={labelClassName} forId={forId} required={required}>
       {label}
     </Label>
   );
@@ -67,6 +67,7 @@ const Field = ({
   help,
   isSelect,
   label,
+  labelClassName,
   labelFirst = true,
   required,
   stacked,
@@ -74,7 +75,13 @@ const Field = ({
   type,
   ...props
 }) => {
-  const labelNode = generateLabel(forId, required, label, stacked);
+  const labelNode = generateLabel(
+    forId,
+    required,
+    label,
+    labelClassName,
+    stacked
+  );
   const content = generateContent(
     isSelect,
     children,
@@ -101,18 +108,19 @@ const Field = ({
 };
 
 Field.propTypes = {
-  caution: PropTypes.string,
+  caution: PropTypes.node,
   children: PropTypes.node,
   className: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.node,
   forId: PropTypes.string,
   help: PropTypes.node,
   isSelect: PropTypes.bool,
   label: PropTypes.node,
+  labelClassName: PropTypes.string,
   labelFirst: PropTypes.bool,
   required: PropTypes.bool,
   stacked: PropTypes.bool,
-  success: PropTypes.string,
+  success: PropTypes.node,
 };
 
 export default Field;

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -106,7 +106,7 @@ Field.propTypes = {
   className: PropTypes.string,
   error: PropTypes.string,
   forId: PropTypes.string,
-  help: PropTypes.string,
+  help: PropTypes.node,
   isSelect: PropTypes.bool,
   label: PropTypes.node,
   labelFirst: PropTypes.bool,

--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -32,12 +32,34 @@ describe("Field ", () => {
     expect(wrapper.prop("className").includes("is-caution")).toBe(true);
   });
 
+  it("can display a caution node", () => {
+    const wrapper = shallow(<Field caution={<span>Are you sure?</span>} />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Caution"}:</strong> <span>Are you sure?</span>
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-caution")).toBe(true);
+  });
+
   it("can display an error message", () => {
     const wrapper = shallow(<Field error="You can't do that" />);
     compareJSX(
       wrapper.find(".p-form-validation__message"),
       <p className="p-form-validation__message">
         <strong>{"Error"}:</strong> {"You can't do that"}
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-error")).toBe(true);
+  });
+
+  it("can display an error node", () => {
+    const wrapper = shallow(<Field error={<span>You can't do that</span>} />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Error"}:</strong> <span>You can't do that</span>
       </p>
     );
     expect(wrapper.prop("className").includes("is-error")).toBe(true);
@@ -54,6 +76,17 @@ describe("Field ", () => {
     expect(wrapper.prop("className").includes("is-success")).toBe(true);
   });
 
+  it("can display a success node", () => {
+    const wrapper = shallow(<Field success={<span>You did it!</span>} />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Success"}:</strong> <span>You did it!</span>
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-success")).toBe(true);
+  });
+
   it("can display a help message", () => {
     const wrapper = shallow(<Field help="This is how you do it" />);
     expect(wrapper.find(".p-form-help-text").text()).toEqual(
@@ -64,9 +97,6 @@ describe("Field ", () => {
   it("can display a help node", () => {
     const wrapper = shallow(
       <Field help={<span>This is how you do it</span>} />
-    );
-    expect(wrapper.find(".p-form-help-text").text()).toEqual(
-      "This is how you do it"
     );
     compareJSX(
       wrapper.find(".p-form-help-text"),
@@ -86,6 +116,18 @@ describe("Field ", () => {
     const wrapper = shallow(<Field labelFirst={false} label="Test label" />);
     // The label should be inside the control.
     expect(wrapper.find(".p-form__control Label").length).toBe(1);
+  });
+
+  it("can display a label node", () => {
+    const wrapper = shallow(<Field label={<span>Test label</span>} />);
+    compareJSX(wrapper.find("Label").children(), <span>Test label</span>);
+  });
+
+  it("can pass a class name to the label", () => {
+    const wrapper = shallow(
+      <Field label={<span>Test label</span>} labelClassName="custom-label" />
+    );
+    expect(wrapper.find("Label").prop("className")).toBe("custom-label");
   });
 
   it("can be required", () => {

--- a/src/components/Field/Field.test.js
+++ b/src/components/Field/Field.test.js
@@ -61,6 +61,21 @@ describe("Field ", () => {
     );
   });
 
+  it("can display a help node", () => {
+    const wrapper = shallow(
+      <Field help={<span>This is how you do it</span>} />
+    );
+    expect(wrapper.find(".p-form-help-text").text()).toEqual(
+      "This is how you do it"
+    );
+    compareJSX(
+      wrapper.find(".p-form-help-text"),
+      <p className="p-form-help-text">
+        <span>This is how you do it</span>
+      </p>
+    );
+  });
+
   it("can display the label before the input", () => {
     const wrapper = shallow(<Field labelFirst={true} label="Test label" />);
     // The label should not be inside the control.

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -12,6 +12,7 @@ const Input = ({
   help,
   id,
   label,
+  labelClassName,
   required,
   stacked,
   success,
@@ -27,6 +28,7 @@ const Input = ({
       forId={id}
       help={help}
       label={label}
+      labelClassName={labelClassName}
       labelFirst={labelFirst}
       required={required}
       stacked={stacked}
@@ -43,16 +45,17 @@ const Input = ({
 };
 
 Input.propTypes = {
-  caution: PropTypes.string,
+  caution: PropTypes.node,
   className: PropTypes.string,
   wrapperClassName: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.node,
   help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node,
+  labelClassName: PropTypes.string,
   required: PropTypes.bool,
   stacked: PropTypes.bool,
-  success: PropTypes.string,
+  success: PropTypes.node,
   type: PropTypes.string,
 };
 

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -47,7 +47,7 @@ Input.propTypes = {
   className: PropTypes.string,
   wrapperClassName: PropTypes.string,
   error: PropTypes.string,
-  help: PropTypes.string,
+  help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node,
   required: PropTypes.bool,

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -18,21 +18,25 @@ const Select = ({
   help,
   id,
   label,
+  labelClassName,
   onChange,
   options,
   required,
   stacked,
   success,
+  wrapperClassName,
   ...props
 }) => {
   return (
     <Field
       caution={caution}
+      className={wrapperClassName}
       error={error}
       forId={id}
       help={help}
       isSelect={true}
       label={label}
+      labelClassName={labelClassName}
       required={required}
       stacked={stacked}
       success={success}
@@ -50,12 +54,13 @@ const Select = ({
 };
 
 Select.propTypes = {
-  caution: PropTypes.string,
+  caution: PropTypes.node,
   className: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.node,
   help: PropTypes.node,
   id: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.node,
+  labelClassName: PropTypes.string,
   onChange: PropTypes.func,
   options: PropTypes.arrayOf(
     PropTypes.shape({
@@ -65,7 +70,8 @@ Select.propTypes = {
   ).isRequired,
   required: PropTypes.bool,
   stacked: PropTypes.bool,
-  success: PropTypes.string,
+  success: PropTypes.node,
+  wrapperClassName: PropTypes.string,
 };
 
 export default Select;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -53,7 +53,7 @@ Select.propTypes = {
   caution: PropTypes.string,
   className: PropTypes.string,
   error: PropTypes.string,
-  help: PropTypes.string,
+  help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -12,20 +12,24 @@ const Textarea = ({
   help,
   id,
   label,
+  labelClassName,
   onKeyUp,
   required,
   stacked,
   style,
   success,
+  wrapperClassName,
   ...props
 }) => {
   return (
     <Field
       caution={caution}
+      className={wrapperClassName}
       error={error}
       forId={id}
       help={help}
       label={label}
+      labelClassName={labelClassName}
       required={required}
       stacked={stacked}
       success={success}
@@ -56,18 +60,20 @@ const Textarea = ({
 };
 
 Textarea.propTypes = {
-  caution: PropTypes.string,
+  caution: PropTypes.node,
   className: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.node,
   grow: PropTypes.bool,
   help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node,
+  labelClassName: PropTypes.string,
   onKeyUp: PropTypes.func,
   required: PropTypes.bool,
   stacked: PropTypes.bool,
   style: PropTypes.object,
-  success: PropTypes.string,
+  success: PropTypes.node,
+  wrapperClassName: PropTypes.string,
 };
 
 export default Textarea;

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -60,7 +60,7 @@ Textarea.propTypes = {
   className: PropTypes.string,
   error: PropTypes.string,
   grow: PropTypes.bool,
-  help: PropTypes.string,
+  help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node,
   onKeyUp: PropTypes.func,


### PR DESCRIPTION
## Done:
- Update Field to support a React node to be supplied for the help prop.
- Update components that pass help to Field.

QA: None, tests should pass.

Fixes: https://github.com/canonical-web-and-design/react-components/issues/195.
Fixes: https://github.com/canonical-web-and-design/react-components/issues/67.