### PR TITLE
Allow form elements to take focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+### Added
+
+- Updated Input, Select and Textarea to have a takeFocus prop which sets the focus to the input on first render.
+
 ## [0.8.1] - 2020-07-16
 
 ### Changed

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 import Field from "../Field";
 
@@ -16,10 +16,19 @@ const Input = ({
   required,
   stacked,
   success,
+  takeFocus,
   type,
   ...props
 }) => {
+  const inputRef = useRef();
   const labelFirst = !["checkbox", "radio"].includes(type);
+
+  useEffect(() => {
+    if (takeFocus) {
+      inputRef.current.focus();
+    }
+  }, [takeFocus]);
+
   return (
     <Field
       caution={caution}
@@ -37,6 +46,7 @@ const Input = ({
       <input
         className={classNames("p-form-validation__input", className)}
         id={id}
+        ref={inputRef}
         type={type}
         {...props}
       />
@@ -56,6 +66,10 @@ Input.propTypes = {
   required: PropTypes.bool,
   stacked: PropTypes.bool,
   success: PropTypes.node,
+  /**
+   * Focus on the input on first render.
+   */
+  takeFocus: PropTypes.bool,
   type: PropTypes.string,
 };
 

--- a/src/components/Input/Input.test.js
+++ b/src/components/Input/Input.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Input from "./Input";
@@ -24,5 +24,10 @@ describe("Input ", () => {
   it("moves the label for checkboxes", () => {
     const wrapper = shallow(<Input type="checkbox" />);
     expect(wrapper.prop("labelFirst")).toBe(false);
+  });
+
+  it("can take focus on first render", () => {
+    const wrapper = mount(<Input takeFocus />);
+    expect(wrapper.find("input").getDOMNode()).toBe(document.activeElement);
   });
 });

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 import Field from "../Field";
 
@@ -24,9 +24,18 @@ const Select = ({
   required,
   stacked,
   success,
+  takeFocus,
   wrapperClassName,
   ...props
 }) => {
+  const selectRef = useRef();
+
+  useEffect(() => {
+    if (takeFocus) {
+      selectRef.current.focus();
+    }
+  }, [takeFocus]);
+
   return (
     <Field
       caution={caution}
@@ -45,6 +54,7 @@ const Select = ({
         className={classNames("p-form-validation__input", className)}
         id={id}
         onChange={(evt) => onChange && onChange(evt)}
+        ref={selectRef}
         {...props}
       >
         {generateOptions(options)}
@@ -71,6 +81,10 @@ Select.propTypes = {
   required: PropTypes.bool,
   stacked: PropTypes.bool,
   success: PropTypes.node,
+  /**
+   * Focus on the select box on first render.
+   */
+  takeFocus: PropTypes.bool,
   wrapperClassName: PropTypes.string,
 };
 

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Select from "./Select";
@@ -34,5 +34,10 @@ describe("Select ", () => {
     const className = wrapper.find("select").prop("className");
     expect(className.includes("p-form-validation__input")).toBe(true);
     expect(className.includes("extra-class")).toBe(true);
+  });
+
+  it("can take focus on first render", () => {
+    const wrapper = mount(<Select options={[]} takeFocus />);
+    expect(wrapper.find("select").getDOMNode()).toBe(document.activeElement);
   });
 });

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 import Field from "../Field";
 
@@ -18,9 +18,18 @@ const Textarea = ({
   stacked,
   style,
   success,
+  takeFocus,
   wrapperClassName,
   ...props
 }) => {
+  const textareaRef = useRef();
+
+  useEffect(() => {
+    if (takeFocus) {
+      textareaRef.current.focus();
+    }
+  }, [takeFocus]);
+
   return (
     <Field
       caution={caution}
@@ -43,6 +52,7 @@ const Textarea = ({
               evt.currentTarget.scrollHeight + "px";
           }
         }}
+        ref={textareaRef}
         style={
           (grow && {
             minHeight: "5rem",
@@ -73,6 +83,10 @@ Textarea.propTypes = {
   stacked: PropTypes.bool,
   style: PropTypes.object,
   success: PropTypes.node,
+  /**
+   * Focus on the textarea on first render.
+   */
+  takeFocus: PropTypes.bool,
   wrapperClassName: PropTypes.string,
 };
 

--- a/src/components/Textarea/Textarea.test.js
+++ b/src/components/Textarea/Textarea.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Textarea from "./Textarea";
@@ -14,5 +14,10 @@ describe("Textarea ", () => {
     const className = wrapper.find("textarea").prop("className");
     expect(className.includes("p-form-validation__input")).toBe(true);
     expect(className.includes("extra-class")).toBe(true);
+  });
+
+  it("can take focus on first render", () => {
+    const wrapper = mount(<Textarea takeFocus />);
+    expect(wrapper.find("textarea").getDOMNode()).toBe(document.activeElement);
   });
 });


### PR DESCRIPTION
## Done

- Updated Input, Select and Textarea to have a takeFocus prop which sets the focus to the input on first render.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Add `setFocus` to a Story for each of Input, Select and Textarea.
- Run story book and open the docs tab for each component. The inputs should take focus.

## Fixes

Required by: https://github.com/canonical-web-and-design/maas-ui/issues/1469.
