### PR TITLE
chore: update gitignore with cypress artifacts.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,4 @@
   - src/**/*
 Maintenance 🔨:
   - package.json
+  - .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .env.local
+.DS_Store
 
 .docker-project
 .yarn.*
@@ -11,3 +12,6 @@ yarn-debug.log*
 yarn-error.log*
 
 storybook-static/
+
+cypress/screenshots/
+cypress/videos


### PR DESCRIPTION
## Done

- Add cypress videos and screenshots to gitignore.
- Add macos .DS_Store to gitignore.
- Add .gitignore to Maintenance labeller.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- n/a

## Fixes

Fixes: # .
