### PR TITLE
doc: add sass-loader requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ See the [component docs](https://canonical-web-and-design.github.io/react-compon
 ![CI](https://github.com/canonical-web-and-design/react-components/workflows/CI/badge.svg?branch=master)
 ![Cypress chrome headless](https://github.com/canonical-web-and-design/react-components/workflows/Cypress%20chrome%20headless/badge.svg)
 
+## Requirements
+
+Canonical react components currently require that your build is configured with [sass-loader](https://github.com/webpack-contrib/sass-loader) (or equivalent), to compile sass.
+
 ## Install
 
 To use the [NPM package](https://www.npmjs.com/package/@canonical/react-components) do:


### PR DESCRIPTION
## Done
Vanilla is built on sass, consequently any project using react-components must be configured to compile sass.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- n/a

## Fixes

Fixes: #262
