### PR TITLE
Update ModularTable examples

### DIFF
--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -51,14 +51,14 @@ ModularTable components accepts `columns` and `data` arguments in the same forma
             Cell: ({ value }) => {
               switch (value) {
                 case "released":
-                  return <><i className="p-icon--success"></i> Released</>;
+                  return <><i className="p-icon--success"></i>Released</>;
                 case "failed":
-                  return <><i className="p-icon--success"></i> Released</>;
+                  return <><i className="p-icon--error"></i>Failed</>;
                 default:
                   return "Unknown";
               }
             },
-            className: "has-icon",
+            className: "p-table__cell--icon-placeholder",
           },
           {
             Header: "Build Finished",

--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -34,6 +34,7 @@ ModularTable components accepts `columns` and `data` arguments in the same forma
           {
             Header: "ID",
             accessor: "buildId",
+            Cell: ({ value }) => <a href="#">#{ value }</a>,
           },
           {
             Header: "Architecture",
@@ -47,6 +48,16 @@ ModularTable components accepts `columns` and `data` arguments in the same forma
           {
             Header: "Result",
             accessor: "result",
+            Cell: ({ value }) => {
+              switch (value) {
+                case "released":
+                  return <><i className="p-icon--success"></i> Released</>;
+                case "failed":
+                  return <><i className="p-icon--success"></i> Released</>;
+                default:
+                  return "Unknown";
+              }
+            },
             className: "has-icon",
           },
           {
@@ -60,17 +71,17 @@ ModularTable components accepts `columns` and `data` arguments in the same forma
       data={React.useMemo(
         () => [
           {
-            buildId: "#5432",
+            buildId: "5432",
             arch: "arm64",
             duration: "5 minutes",
-            result: <><i className="p-icon--success"></i> Released</>,
+            result: "released",
             finished: "10 minutes ago",
           },
           {
-            buildId: "#1234",
+            buildId: "1234",
             arch: "armhf",
             duration: "5 minutes",
-            result: <><i className="p-icon--error"></i> Failed to build</>,
+            result: "failed",
             finished: "over 1 year ago",
           },
         ],

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -77,7 +77,7 @@ ModularTable.propTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       Header: PropTypes.node,
-      accessor: PropTypes.string,
+      accessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       className: PropTypes.string,
     }).isRequired
   ),


### PR DESCRIPTION
## Done

- Makes sure ModularTable example correctly uses primitive table data and formats the cells in Cell components
- Updates Vanilla to 2.19 and uses new table cell icon class in examples

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to ModularTable story book page
- Make sure it renders correctly
- Make sure cells with icons have `p-table__cell--icon-placeholder` class names.


