### PR TITLE
Set the component name for SearchBox.

### DIFF
--- a/src/components/SearchAndFilter/SearchAndFilter.test.js
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.js
@@ -29,7 +29,10 @@ describe("Search and filter", () => {
   it("renders", () => {
     const returnSearchData = jest.fn();
     const wrapper = shallow(
-      <SearchAndFilter returnSearchData={returnSearchData} />
+      <SearchAndFilter
+        filterPanelData={[]}
+        returnSearchData={returnSearchData}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -37,7 +40,10 @@ describe("Search and filter", () => {
   it("hide the clear button when there is no value in search box", () => {
     const returnSearchData = jest.fn();
     const wrapper = mount(
-      <SearchAndFilter returnSearchData={returnSearchData} />
+      <SearchAndFilter
+        filterPanelData={[]}
+        returnSearchData={returnSearchData}
+      />
     );
     expect(wrapper.find(".p-search-box__reset").exists()).toBe(false);
   });

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
@@ -10,7 +10,7 @@ exports[`Search and filter renders 1`] = `
     data-active={true}
     data-empty={true}
   >
-    <ForwardRef
+    <SearchBox
       autocomplete="off"
       data-overflowing={false}
       externallyControlled={true}
@@ -21,6 +21,12 @@ exports[`Search and filter renders 1`] = `
       placeholder="Search and filter"
       value=""
     />
+  </div>
+  <div
+    aria-hidden={true}
+    className="search-and-filter__panel"
+  >
+    <ContextualMenu />
   </div>
 </div>
 `;

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -87,4 +87,6 @@ SearchBox.propTypes = {
   value: PropTypes.string,
 };
 
+SearchBox.displayName = "SearchBox";
+
 export default SearchBox;

--- a/src/components/SearchBox/SearchBox.test.js
+++ b/src/components/SearchBox/SearchBox.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import React from "react";
 
 import SearchBox from "./SearchBox";
@@ -24,5 +24,15 @@ describe("SearchBox ", () => {
     wrapper.setProps({ value: "new-admin" });
     input = wrapper.find(".p-search-box__input");
     expect(input.prop("value")).toBe("new-admin");
+  });
+
+  it("can be found using the component name", () => {
+    const WrappingComponent = () => (
+      <div>
+        <SearchBox />
+      </div>
+    );
+    const wrapper = mount(<WrappingComponent />);
+    expect(wrapper.find("SearchBox").exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Done

- Set the display name for SearchBox so that it does not appear as "ForwardRef".

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

No QA.

## Fixes

Fixes: #281
