### PR TITLE
Fix u-hide override affecting expanding table headers

### DIFF
--- a/src/components/ModularTable/ModularTable.scss
+++ b/src/components/ModularTable/ModularTable.scss
@@ -5,29 +5,31 @@
 // Vanilla issue: https://github.com/canonical-web-and-design/vanilla-framework/issues/3337
 
 // stylelint-disable selector-no-qualifying-type
-td.u-hide,
-th.u-hide {
-  display: table-cell !important;
-  width: 0 !important;
+.p-modular-table {
+  td.u-hide,
+  th.u-hide {
+    display: table-cell !important;
+    width: 0 !important;
 
-  &--small {
-    @media screen and (max-width: $breakpoint-medium) {
-      display: table-cell !important;
-      width: 0 !important;
+    &--small {
+      @media screen and (max-width: $breakpoint-medium) {
+        display: table-cell !important;
+        width: 0 !important;
+      }
     }
-  }
 
-  &--medium {
-    @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
-      display: table-cell !important;
-      width: 0 !important;
+    &--medium {
+      @media (min-width: $breakpoint-medium) and (max-width: $breakpoint-large) {
+        display: table-cell !important;
+        width: 0 !important;
+      }
     }
-  }
 
-  &--large {
-    @media screen and (min-width: $breakpoint-large) {
-      display: table-cell !important;
-      width: 0 !important;
+    &--large {
+      @media screen and (min-width: $breakpoint-large) {
+        display: table-cell !important;
+        width: 0 !important;
+      }
     }
   }
 }

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -35,7 +35,7 @@ function ModularTable({
   const showEmpty: boolean = emptyMsg && (!rows || rows.length === 0);
 
   return (
-    <Table {...getTableProps()}>
+    <Table {...getTableProps({ className: "p-modular-table" })}>
       <thead>
         {headerGroups.map((headerGroup) => (
           <TableRow {...headerGroup.getHeaderGroupProps()}>


### PR DESCRIPTION
## Done

- Namespaced `ModularTable.scss` so that the `u-hide` override would not affect expanding tables.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Run `yarn docs`
- Navigate to the MainTable > Expanding story
- Check that the table headers are correctly aligned with the content
