### PR TITLE
Add classes to the wrapping tooltip elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated expanding MainTable to use aria-hidden instead of .u-hide utility class
 - Updated Vanilla framework to version 2.19.2
-- Added class names to the wrapping elements for the Tooltip component.
+- Added `positionElementClassName` prop to allow class names to be passed to the position element for the Tooltip component.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated expanding MainTable to use aria-hidden instead of .u-hide utility class
 - Updated Vanilla framework to version 2.19.2
+- Added class names to the wrapping elements for the Tooltip component.
 
 ### Removed
 

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -50,3 +50,22 @@ An alternative use of tooltips is to provide information on a disabled actionabl
     {Template.bind({})}
   </Story>
 </Canvas>
+
+### Targeting elements
+
+The tooltip elements are displayed inside a [Portal](https://reactjs.org/docs/portals.html) so that the tooltip is not constrained by its current position in the DOM.
+Sometimes however, you need to target the tooltip elements. This can be achieved by passing class names to the tooltip elements. You can also pass classes to the elements that trigger and position the tooltip.
+
+<Canvas>
+  <Story
+    name="Targeting elements"
+    args={{
+      className: "custom-wrapping-class",
+      positionElementClassName: "custom-position-class",
+      tooltipClassName: "custom-tooltip-class",
+      message: "Tooltip message to display.",
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -215,13 +215,17 @@ const Tooltip = ({
     <>
       {message ? (
         <span
-          className={className}
+          className={classNames("p-tooltip--wrapper", className)}
           onBlur={closePortal}
           onFocus={openPortal}
           onMouseOut={closePortal}
           onMouseOver={openPortal}
         >
-          <span ref={wrapperRef} style={{ display: "inline-block" }}>
+          <span
+            className="p-tooltip--wrapper-inner"
+            ref={wrapperRef}
+            style={{ display: "inline-block" }}
+          >
             {children}
           </span>
           {isOpen && (
@@ -246,7 +250,9 @@ const Tooltip = ({
           )}
         </span>
       ) : (
-        <span className={className}>{children}</span>
+        <span className={classNames("p-tooltip--wrapper", className)}>
+          {children}
+        </span>
       )}
     </>
   );

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -40,6 +40,7 @@ export type Props = {
   followMouse?: boolean;
   message?: string;
   position?: Position;
+  positionElementClassName?: string;
   tooltipClassName?: string;
 };
 
@@ -144,6 +145,7 @@ export const adjustForWindow = (
  * @param [followMouse=false] Whether the tooltip should follow the mouse.
  * @param message Message to display when the element is hovered.
  * @param [position="top-left"] Position of the tooltip relative to the element.
+ * @param positionElementClassName An optional class to apply to the element that wraps the children.
  * @param tooltipClassName An optional class to apply to the tooltip message element.
  */
 const Tooltip = ({
@@ -153,6 +155,7 @@ const Tooltip = ({
   followMouse = false,
   message,
   position = "top-left",
+  positionElementClassName,
   tooltipClassName,
 }: Props): JSX.Element => {
   const wrapperRef = useRef<HTMLElement>(null);
@@ -215,14 +218,14 @@ const Tooltip = ({
     <>
       {message ? (
         <span
-          className={classNames("p-tooltip--wrapper", className)}
+          className={className}
           onBlur={closePortal}
           onFocus={openPortal}
           onMouseOut={closePortal}
           onMouseOver={openPortal}
         >
           <span
-            className="p-tooltip--wrapper-inner"
+            className={positionElementClassName}
             ref={wrapperRef}
             style={{ display: "inline-block" }}
           >
@@ -250,9 +253,7 @@ const Tooltip = ({
           )}
         </span>
       ) : (
-        <span className={classNames("p-tooltip--wrapper", className)}>
-          {children}
-        </span>
+        <span className={className}>{children}</span>
       )}
     </>
   );
@@ -292,6 +293,10 @@ Tooltip.propTypes = {
     "top-left",
     "top-right",
   ]),
+  /**
+   * An optional class to apply to the element that wraps the children.
+   */
+  positionElementClassName: PropTypes.node,
   /**
    * An optional class to apply to the tooltip message element.
    */

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -3,12 +3,14 @@
 exports[`<Tooltip /> renders and matches the snapshot 1`] = `
 <Fragment>
   <span
+    className="p-tooltip--wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseOut={[Function]}
     onMouseOver={[Function]}
   >
     <span
+      className="p-tooltip--wrapper-inner"
       style={
         Object {
           "display": "inline-block",

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -3,14 +3,12 @@
 exports[`<Tooltip /> renders and matches the snapshot 1`] = `
 <Fragment>
   <span
-    className="p-tooltip--wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseOut={[Function]}
     onMouseOver={[Function]}
   >
     <span
-      className="p-tooltip--wrapper-inner"
       style={
         Object {
           "display": "inline-block",


### PR DESCRIPTION
## Done

- Added classnames to the wrapping tooltip elements.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- View the Tooltip page in Storybook.
- Inspect an element that displays a tooltip. You should see classes applied to the wrapping elements.

## Fixes

Needed for: https://github.com/canonical-web-and-design/maas-ui/issues/1784.
