### PR TITLE
Make Vanilla a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "stylelint-scss": "3.18.0",
     "ts-jest": "26.4.1",
     "typescript": "4.0.3",
+    "vanilla-framework": "2.19.2",
     "wait-on": "5.2.0"
   },
   "dependencies": {
@@ -82,12 +83,12 @@
     "prop-types": "15.7.2",
     "react-table": "7.6.0",
     "react-transition-group": "4.4.1",
-    "react-useportal": "1.0.13",
-    "vanilla-framework": "2.19.2"
+    "react-useportal": "1.0.13"
   },
   "peerDependencies": {
     "react": "16.14.0",
-    "react-dom": "16.14.0"
+    "react-dom": "16.14.0",
+    "vanilla-framework": "2.19.2"
   },
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files --extensions '.js,.jsx,.ts,.tsx'; yarn build-declaration",


### PR DESCRIPTION
## Done

- Added Vanilla as peer and dev dependencies.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Use `yarn link` to test this with another project.

## Fixes

Fixes: #322 .
