### PR TITLE
fix: allow null assignment to tooltip message

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -38,7 +38,7 @@ export type Props = {
   className?: string;
   children: ReactNode;
   followMouse?: boolean;
-  message?: string;
+  message?: string | null;
   position?: Position;
   positionElementClassName?: string;
   tooltipClassName?: string;


### PR DESCRIPTION
## Done
As the Tooltip component allows you to control conditional rendering of the tooltip with the message prop, we should allow this to be explicitly assigned null.

This is useful when you are setting `message` in a ternary, e.g.

```ts
<Tooltip message={foo? "please render me": null} />
```

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- n/a

## Fixes

Fixes: # .
