### PR TITLE
Remove ContextualMenu / CSSTransition

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,10 @@
     "@types/react": "16.9.53",
     "@types/react-dom": "16.9.8",
     "@types/react-table": "7.0.24",
-    "@types/react-transition-group": "4.4.0",
     "classnames": "2.2.6",
     "nanoid": "3.1.16",
     "prop-types": "15.7.2",
     "react-table": "7.6.0",
-    "react-transition-group": "4.4.1",
     "react-useportal": "1.0.13"
   },
   "peerDependencies": {

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
@@ -62,7 +62,7 @@ const FilterPanelSection = ({
       updateFlowCount();
     }
     return () => {
-      resizeObserverSupported && wrapperWidthObserver.disconnect();
+      resizeObserverSupported && wrapperWidthObserver?.disconnect();
     };
   }, [panelSectionVisible]);
 

--- a/src/components/SearchAndFilter/SearchAndFilter.scss
+++ b/src/components/SearchAndFilter/SearchAndFilter.scss
@@ -6,6 +6,7 @@
 
   &__search-container {
     align-items: center;
+    background-color: $color-x-light;
     display: flex;
     flex-wrap: wrap;
     height: auto;
@@ -15,20 +16,13 @@
     padding: 0 2rem 0 0.5rem;
     position: relative;
 
-    &[data-empty="false"] {
-      height: 40px;
-    }
-
     &[data-active="true"] {
       height: auto;
     }
 
-    // if search container is not active
-    &[data-active="false"] {
-      // hide the overflowing input field
-      [data-overflowing="true"] {
-        display: none;
-      }
+    &[data-empty="false"],
+    &[aria-expanded="false"] {
+      height: 40px;
     }
 
     .p-chip {
@@ -68,7 +62,14 @@
   }
 
   &__panel {
-    padding: 0;
+    border-radius: $border-radius;
+    box-shadow: $box-shadow;
+    opacity: 1;
+    padding: 0.5rem 1rem 0;
+    position: absolute;
+    transition: opacity 0.25s;
+    width: 100%;
+    z-index: 9999;
 
     &[aria-hidden="true"] {
       opacity: 0;
@@ -95,7 +96,7 @@
     position: absolute;
     right: 3px;
     top: 3px;
-    z-index: 999;
+    z-index: 9999;
   }
 
   .p-search-box {
@@ -124,37 +125,5 @@
   .p-search-box__button,
   .p-search-box__reset {
     display: none;
-  }
-
-  &__contextual-menu {
-    display: block;
-
-    .p-contextual-menu__dropdown {
-      padding: 1rem;
-    }
-
-    // These class names are manually provided to the CSSTransition component
-    // in SearchAndFilter.
-    &--transition {
-      &-enter,
-      &-appear {
-        opacity: 0;
-      }
-
-      &-enter-active,
-      &-appear-active {
-        opacity: 1;
-        transition: opacity 0.25s;
-      }
-
-      &-exit {
-        opacity: 1;
-      }
-
-      &-exit-active {
-        opacity: 0;
-        transition: opacity 0.25s;
-      }
-    }
   }
 }

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.js.snap
@@ -25,34 +25,7 @@ exports[`Search and filter renders 1`] = `
     aria-hidden={true}
     className="search-and-filter__panel"
   >
-    <ContextualMenu
-      autoAdjust={false}
-      className="search-and-filter__contextual-menu"
-      constrainPanelWidth={true}
-      dropdownClassName="search-and-filter__dropdown"
-      onToggleMenu={[Function]}
-      position="left"
-      visible={false}
-    >
-      <CSSTransition
-        appear={true}
-        classNames={
-          Object {
-            "appear": "search-and-filter__contextual-menu--transition-appear",
-            "appearActive": "search-and-filter__contextual-menu--transition-appear-active",
-            "appearDone": "search-and-filter__contextual-menu--transition-appear-done",
-            "enter": "search-and-filter__contextual-menu--transition-enter",
-            "enterActive": "search-and-filter__contextual-menu--transition-enter-active",
-            "enterDone": "search-and-filter__contextual-menu--transition-enter-done",
-            "exit": "search-and-filter__contextual-menu--transition-exit",
-            "exitActive": "search-and-filter__contextual-menu--transition-exit-active",
-            "exitDone": "search-and-filter__contextual-menu--transition-exit-done",
-          }
-        }
-        in={true}
-        timeout={200}
-      />
-    </ContextualMenu>
+    <div />
   </div>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,7 +1114,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -2634,13 +2634,6 @@
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
   integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
-  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
   dependencies:
     "@types/react" "*"
 
@@ -5492,14 +5485,6 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
-  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -9765,15 +9750,15 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
+nanoid@3.1.16:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
+
 nanoid@^3.1.12:
   version "3.1.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
-
-nanoid@^3.1.16:
-  version "3.1.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
-  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -11434,16 +11419,6 @@ react-textarea-autosize@^8.1.1:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
-
-react-transition-group@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
-  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react-useportal@1.0.13:
   version "1.0.13"


### PR DESCRIPTION
## Done

- Decouple ContextualMenu / CSSTransition from Search And Filter
- Ensure panel stays open when clicking inside component

## Why

- ContextualMenu has grown far too complex to be used in this context. It also uses inline styles which make it very difficult to override when nested inside SearchAndFilter.
- CSSTransiton adds many levels of complexity and is also not compatible downstream when consumed by React projects in Strict mode.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

Fixes #320, Fixes #315 

- Go to search and filter pattern
- Ensure it displays and works as expected