### PR TITLE
Remove .p-summary__text scss

### DIFF
--- a/src/components/SummaryButton/SummaryButton.scss
+++ b/src/components/SummaryButton/SummaryButton.scss
@@ -1,6 +1,0 @@
-@import "~vanilla-framework/scss/settings";
-
-.p-summary__text {
-  display: inline-block;
-  margin-right: $sph-inner--small;
-}

--- a/src/components/SummaryButton/SummaryButton.tsx
+++ b/src/components/SummaryButton/SummaryButton.tsx
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 
 import ActionButton from "../ActionButton";
 
-import "./SummaryButton.scss";
-
 type Props = {
   className?: string;
   label: string;
@@ -21,13 +19,11 @@ const SummaryButton = ({
   onClick,
 }: Props): JSX.Element => (
   <small className={className}>
-    {summary && (
-      <span className="p-summary__text u-text--muted">{summary}</span>
-    )}
+    {summary && <span className="u-text--muted">{summary}</span>}
     {onClick && (
       <ActionButton
         appearance="neutral"
-        className="is-small is-dense"
+        className="is-small is-dense is-inline"
         onClick={onClick}
         loading={isLoading}
         disabled={isLoading}

--- a/src/components/SummaryButton/SummaryButton.tsx
+++ b/src/components/SummaryButton/SummaryButton.tsx
@@ -1,5 +1,6 @@
 import React, { SyntheticEvent } from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 import ActionButton from "../ActionButton";
 
@@ -23,7 +24,9 @@ const SummaryButton = ({
     {onClick && (
       <ActionButton
         appearance="neutral"
-        className="is-small is-dense is-inline"
+        className={classNames("is-small", "is-dense", {
+          "is-inline": summary,
+        })}
         onClick={onClick}
         loading={isLoading}
         disabled={isLoading}

--- a/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
+++ b/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`<SummaryButton /> renders and matches the snapshot 1`] = `
 <small>
   <span
-    className="p-summary__text u-text--muted"
+    className="u-text--muted"
   >
     Showing some items
   </span>
   <ActionButton
     appearance="neutral"
-    className="is-small is-dense"
+    className="is-small is-dense is-inline"
     onClick={[Function]}
   >
     Show more


### PR DESCRIPTION
## Done

Removed unnecessary custom styling for the SummaryButton component, used Vanilla's `is-inline` button utility to achieve the same effect.

## QA

### Storybook

Run:

```shell
yarn start
```

Then visit http://localhost:8403:/?path=/story/summarybutton--default-story

### QA steps

- See that the SummaryButton component looks good across all screen widths

## Fixes

Fixes: #368  .

## Screenshots:

Before:
![Screenshot from 2021-01-18 15-00-15](https://user-images.githubusercontent.com/2376968/104931928-fda3b000-599e-11eb-8df0-b2855700f88e.png)

After:
![Screenshot from 2021-01-18 14-57-59](https://user-images.githubusercontent.com/2376968/104931948-01cfcd80-599f-11eb-9982-16c97d4861ae.png)

