### PR TITLE
allow custom classNames for Icon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `classNames` prop to Icon component
+
 ### Changed
 
 - Removed custom styling from Spinner component

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -13,4 +13,9 @@ describe("Icon", () => {
     const wrapper = shallow(<Icon name="test" />);
     expect(wrapper.prop("className").includes("p-icon--test")).toBe(true);
   });
+
+  it("can be given a custom class name", () => {
+    const wrapper = shallow(<Icon className="custom-class" name="test" />);
+    expect(wrapper.prop("className")).toBe("custom-class p-icon--test");
+  });
 });

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import classNames from "classnames";
 import PropTypes from "prop-types";
+import React from "react";
 
 export enum ICONS {
   plus = "plus",
@@ -27,6 +28,7 @@ export enum ICONS {
 }
 
 type Props = {
+  className?: string;
   name: ICONS | string;
 };
 
@@ -36,12 +38,13 @@ type Props = {
  * @param name One of built-in Vanilla icons or a name of a custom icon that follows `p-icon--{name}` convention.
  * @returns Icon
  */
-const Icon = ({ name }: Props): JSX.Element => (
-  <i className={`p-icon--${name}`} />
+const Icon = ({ className, name }: Props): JSX.Element => (
+  <i className={classNames(className, `p-icon--${name}`)} />
 );
 
 Icon.propTypes = {
-  name: PropTypes.string,
+  className: PropTypes.string,
+  name: PropTypes.string.isRequired,
 };
 
 export default Icon;


### PR DESCRIPTION
## Done

- Added `className` prop to the Icon component

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check that storybook documents the Icon `className` prop

## Fixes

Fixes #329 
