### PR TITLE
Update ActionButton button to use is-processing classname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `ActionButton` to use `is-processing` classname instead of deprecated `is-active`.
+
 ### Removed
+
+- Removed `p-action-button` class from `ActionButton`, as this is not a separate pattern in Vanilla. If any additional classname needs to be provided for custom styling it can be added via `className` prop.
 
 # 0.15.0 - 2021-02-02
 

--- a/src/components/ActionButton/ActionButton.js
+++ b/src/components/ActionButton/ActionButton.js
@@ -62,16 +62,11 @@ const ActionButton = ({
     return () => clearTimeout(successTimeout);
   }, [showSuccess]);
 
-  const buttonClasses = classNames(
-    className,
-    "p-action-button",
-    `p-button--${appearance}`,
-    {
-      "is-active": showLoader || showSuccess,
-      "is-disabled": disabled,
-      "is-inline": inline,
-    }
-  );
+  const buttonClasses = classNames(className, `p-button--${appearance}`, {
+    "is-processing": showLoader || showSuccess,
+    "is-disabled": disabled,
+    "is-inline": inline,
+  });
 
   const iconClasses = classNames({
     "p-icon--spinner u-animation--spin": showLoader,

--- a/src/components/ActionButton/ActionButton.stories.mdx
+++ b/src/components/ActionButton/ActionButton.stories.mdx
@@ -14,8 +14,6 @@ import ActionButton from "./ActionButton";
   }}
 />
 
-export const Template = (args) => <ActionButton {...args} />;
-
 ### ActionButton
 
 This is a not an existing Vanilla component. It can be used to display submitting states for forms or other actions.
@@ -27,21 +25,15 @@ This is a not an existing Vanilla component. It can be used to display submittin
 ### Default
 
 <Canvas>
-  <Story
-    name="Default"
-    args={{ appearance: "positive", children: "Click me!" }}
-  >
-    {Template.bind({})}
+  <Story name="Default">
+    <ActionButton appearance="positive">Click me!</ActionButton>
   </Story>
 </Canvas>
 
 ### Loading
 
 <Canvas>
-  <Story
-    name="Loading"
-    args={{ appearance: "positive", children: "Click me!", loading: true }}
-  >
-    {Template.bind({})}
+  <Story name="Loading">
+    <ActionButton appearance="positive" loading disabled>Click me!</ActionButton>
   </Story>
 </Canvas>

--- a/src/components/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/src/components/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -5,7 +5,7 @@ exports[`ActionButton matches loading snapshot 1`] = `
   loading={true}
 >
   <button
-    className="p-action-button p-button--neutral is-active"
+    className="p-button--neutral is-processing"
   >
     <i
       className="p-icon--spinner u-animation--spin"
@@ -20,7 +20,7 @@ exports[`ActionButton matches success snapshot 1`] = `
   success={true}
 >
   <button
-    className="p-action-button p-button--neutral is-active"
+    className="p-button--neutral is-processing"
   >
     <i
       className="p-icon--success"


### PR DESCRIPTION
## Done

- Updated `ActionButton` component to use `is-processing` class name instead of deprecated `is-active`
- Removed `p-action-button` class name from `ActionButton`, because it's not a class name provided by Vanilla

## QA

- Check storybook for ActionButton, make sure that examples work as expected
  - https://react-components-384.demos.haus/?path=/docs/actionbutton--default-story

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```
