### PR TITLE
Use node-12 in docker to fix demos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 ADD yarn.lock .


### PR DESCRIPTION
## Done

Fixes demos by using `node-12` instead of `node`

## QA

Make sure demo is running: https://react-components-385.demos.haus/
