### PR TITLE
Add multiple dropdowns support to CodeSnippet component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `CodeSnippet` component, the `Code` component is considered deprecated.
+
 ### Changed
 
 - Updated `ActionButton` to use `is-processing` classname instead of deprecated `is-active`.
+
+### Deprecated
+
+- `Code` component is deprecated. Use `CodeSnippet` component or inline `<code>` instead.
 
 ### Removed
 

--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -2,6 +2,9 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { useRef } from "react";
 
+/**
+ * @deprecated Code component is deprecated. Use CodeSnippet component or inline `<code>` instead.
+ */
 const Code = ({
   children,
   className,

--- a/src/components/Code/Code.stories.mdx
+++ b/src/components/Code/Code.stories.mdx
@@ -18,6 +18,12 @@ export const Template = (args) => <Code {...args} />;
 
 ### Code
 
+<div class="p-notification--caution">
+  <div class="p-notification__response" role="status">
+    <span class="p-notification__status">Deprecated:</span><code>Code</code> component is deprecated. Use <code>CodeSnippet</code> component or inline <code>&lt;code&gt;</code> instead.
+  </div>
+</div>
+
 This is a [React](https://reactjs.org/) component for the Vanilla [Code](https://docs.vanillaframework.io/base/code/).
 
 Vanilla gives you multiple ways to display code using the standard HTML elements.

--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -154,7 +154,7 @@ Multiple dropdowns can be passed in if needed.
   {() => {
     const [channel, setChannel] = useState("stable");
     const [snap, setSnap] = useState("firefox");
-    const code = `sudo snap install ${snap} ${channel !== 'stable' ? "--"+channel : ""}`;
+    const code = `sudo snap install ${snap} ${channel === 'stable' ? "" : "--"+channel}`;
     return <CodeSnippet blocks={[
        {
          title: "Install snap",
@@ -191,7 +191,7 @@ If multiple dropdowns may overlap with long title you can use `stacked` variant,
   {() => {
     const [channel, setChannel] = useState("stable");
     const [snap, setSnap] = useState("firefox");
-    const code = `sudo snap install ${snap} ${channel !== 'stable' ? "--"+channel : ""}`;
+    const code = `sudo snap install ${snap} ${channel === 'stable' ? "" : "--"+channel}`;
     return <CodeSnippet blocks={[
        {
          title: "Install Firefox, Gimp or VLC as a snap from different channels using command line",

--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -120,7 +120,7 @@ Dropdown configuration object is structured as follows:
 With the `options` being an array of option properties compatible with the `Select` options (`[{ label: string, value: string | number }]`).
 
 <Canvas>
-  <Story name="Dropdowns">
+  <Story name="Dropdown">
   {() => {
     const [lang, setLang] = useState("html");
     const code = {
@@ -137,7 +137,7 @@ With the `options` being an array of option properties compatible with the `Sele
               { value: "css", label: "CSS" },
               { value: "html", label: "HTML" },
             ],
-            value: "html",
+            value: lang,
             onChange: (event) => { setLang(event.target.value) }
            }
          ]
@@ -147,3 +147,77 @@ With the `options` being an array of option properties compatible with the `Sele
   </Story>
 </Canvas>
 
+Multiple dropdowns can be passed in if needed.
+
+<Canvas>
+  <Story name="Dropdowns">
+  {() => {
+    const [channel, setChannel] = useState("stable");
+    const [snap, setSnap] = useState("firefox");
+    const code = `sudo snap install ${snap} ${channel !== 'stable' ? "--"+channel : ""}`;
+    return <CodeSnippet blocks={[
+       {
+         title: "Install snap",
+         code: code,
+         dropdowns: [
+           { options: [
+              { value: "stable", label: "stable" },
+              { value: "candidate", label: "candidate" },
+              { value: "beta", label: "beta" },
+              { value: "edge", label: "edge" },
+            ],
+            value: channel,
+            onChange: (event) => { setChannel(event.target.value) }
+           },
+           { options: [
+              { value: "firefox", label: "Firefox" },
+              { value: "gimp", label: "Gimp" },
+              { value: "vlc", label: "VLC" },
+            ],
+            value: snap,
+            onChange: (event) => { setSnap(event.target.value) }
+           }
+         ]
+       },
+     ]} />;
+  }}
+  </Story>
+</Canvas>
+
+If multiple dropdowns may overlap with long title you can use `stacked` variant, by setting the relevant property on code block options.
+
+<Canvas>
+  <Story name="DropdownsStacked">
+  {() => {
+    const [channel, setChannel] = useState("stable");
+    const [snap, setSnap] = useState("firefox");
+    const code = `sudo snap install ${snap} ${channel !== 'stable' ? "--"+channel : ""}`;
+    return <CodeSnippet blocks={[
+       {
+         title: "Install Firefox, Gimp or VLC as a snap from different channels using command line",
+         code: code,
+         stacked: true,
+         dropdowns: [
+           { options: [
+              { value: "stable", label: "stable" },
+              { value: "candidate", label: "candidate" },
+              { value: "beta", label: "beta" },
+              { value: "edge", label: "edge" },
+            ],
+            value: channel,
+            onChange: (event) => { setChannel(event.target.value) }
+           },
+           { options: [
+              { value: "firefox", label: "Firefox" },
+              { value: "gimp", label: "Gimp" },
+              { value: "vlc", label: "VLC" },
+            ],
+            value: snap,
+            onChange: (event) => { setSnap(event.target.value) }
+           }
+         ]
+       },
+     ]} />;
+  }}
+  </Story>
+</Canvas>

--- a/src/components/CodeSnippet/CodeSnippetBlock.tsx
+++ b/src/components/CodeSnippet/CodeSnippetBlock.tsx
@@ -18,6 +18,7 @@ export type CodeSnippetBlockProps = {
   appearance?: CodeSnippetBlockAppearance; //"numbered" | "linuxPrompt" | "windowsPrompt" | "url";
   wrapLines?: boolean;
   dropdowns?: CodeSnippetDropdownProps[];
+  stacked?: boolean;
 };
 
 export default function CodeSnippetBlock({
@@ -26,6 +27,7 @@ export default function CodeSnippetBlock({
   appearance = null,
   wrapLines = false,
   dropdowns,
+  stacked = false,
 }: CodeSnippetBlockProps): JSX.Element {
   let className = "p-code-snippet__block";
   const isNumbered = appearance === CodeSnippetBlockAppearance.NUMBERED;
@@ -62,7 +64,9 @@ export default function CodeSnippetBlock({
   return (
     <>
       {(title || hasDropdowns) && (
-        <div className="p-code-snippet__header">
+        <div
+          className={`p-code-snippet__header ${stacked ? "is-stacked" : ""}`}
+        >
           <h5 className="p-code-snippet__title">{title}</h5>
           {hasDropdowns && (
             <div className="p-code-snippet__dropdowns">
@@ -94,4 +98,5 @@ CodeSnippetBlock.props = {
   ]),
   wrapLines: PropTypes.bool,
   dropdowns: PropTypes.array,
+  stacked: PropTypes.bool,
 };


### PR DESCRIPTION
## Done

- Added support for multiple dropdowns to CodeSnippet component
- Updated storybook and docs
- Deprecated old Code component

## QA

- Review CodeSnippet docs https://react-components-390.demos.haus/?path=/docs/codesnippet--default-story
  - make sure all examples render and work correctly
- Review Code docs https://react-components-390.demos.haus/?path=/docs/code--default-story
  - make sure there is a deprecation note

<img width="1013" alt="Screenshot 2021-02-17 at 07 33 09" src="https://user-images.githubusercontent.com/83575/108165181-6d1dd400-70f2-11eb-925d-9849fa610ba1.png">

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

## Fixes

Fixes: canonical-web-and-design/vanilla-squad#965
