### PR TITLE
Add support for aria-pressed in ContextualMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added support for `aria-pressed` in the ContextualMenu button
+
 ### Removed
 
 # 0.16.0 - 2021-02-17

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -205,6 +205,7 @@ const ContextualMenu = <L,>({
           appearance={toggleAppearance}
           aria-controls={id.current}
           aria-expanded={isOpen ? "true" : "false"}
+          aria-pressed={isOpen ? "true" : "false"}
           aria-haspopup="true"
           className={classNames("p-contextual-menu__toggle", toggleClassName)}
           disabled={toggleDisabled}


### PR DESCRIPTION
## Done

- Adds support for `aria-pressed` in ContextualMenu to show recently added to Vanilla pressed button styles.

## QA

- Open ContextualMenu example, make sure that the button has pressed styles when menu is expanded:
  - https://react-components-396.demos.haus/?path=/docs/contextualmenu--default-story#toggle


<img width="1049" alt="Screenshot 2021-03-02 at 13 56 54" src="https://user-images.githubusercontent.com/83575/109651751-3a96c100-7b5f-11eb-895e-6d2bcab9951b.png">

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```