### PR TITLE
Update table components to Vanilla 2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove unneeded `p-table--sortable`, update class name of `p-table--expanding`
 - Remove `aria-sort` from tables when they are not sortable
 - Updated Vanilla to 2.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Removed
+- Remove `aria-sort` from tables when they are not sortable
+- Updated Vanilla to 2.26.0
 
 # 0.16.1 - 2021-03-02
 

--- a/src/components/MainTable/MainTable.js
+++ b/src/components/MainTable/MainTable.js
@@ -185,7 +185,6 @@ const MainTable = ({
       <Table
         className="p-main-table"
         expanding={expanding}
-        sortable={sortable}
         responsive={responsive}
         {...props}
       >

--- a/src/components/MainTable/MainTable.stories.mdx
+++ b/src/components/MainTable/MainTable.stories.mdx
@@ -1,4 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import { useState } from "react";
 
 import MainTable from "./MainTable";
 import Row from "../Row";
@@ -138,136 +139,129 @@ This is a [React](https://reactjs.org/) component to support many table use case
 
 <Canvas>
   <Story name="Expanding">
-    <MainTable
-      expanding
-      headers={[
-        { content: "Name" },
-        { content: "Mac address" },
-        { content: "IP" },
-        { content: "Rack" },
-        { content: "Last seen" },
-        { content: "Actions", className: "u-align--right" },
-      ]}
-      rows={[
-        {
-          columns: [
-            { content: "Unknown", role: "rowheader" },
-            { content: "2c:44:fd:80:3f:25" },
-            { content: "10.249.0.1" },
-            { content: "karura" },
-            { content: "Thu, 25 Oct. 2018 13:55:21" },
+    {() => {
+      let [expandedRow, setExpandedRow] = useState(1);
+      return (
+        <MainTable
+          expanding
+          headers={[
+            { content: "Name" },
+            { content: "Mac address" },
+            { content: "IP" },
+            { content: "Rack" },
+            { content: "Last seen" },
+            { content: "Actions", className: "u-align--right" },
+          ]}
+          rows={[
             {
-              content: (
-                <button
-                  className="u-toggle"
-                  onClick={() =>
-                    setState({
-                      expandedRow: 1,
-                    })
-                  }
-                >
-                  Show
-                </button>
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "2c:44:fd:80:3f:25" },
+                { content: "10.249.0.1" },
+                { content: "karura" },
+                { content: "Thu, 25 Oct. 2018 13:55:21" },
+                {
+                  content: (
+                    <button
+                      className="u-toggle"
+                      onClick={() => setExpandedRow(1)}
+                    >
+                      Show
+                    </button>
+                  ),
+                  className: "u-align--right",
+                },
+              ],
+              expanded: expandedRow === 1,
+              expandedContent: (
+                <Row>
+                  <Col size="8">
+                    <h4>Expanding table cell</h4>
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                      Consequuntur cum dicta beatae nostrum eligendi similique
+                      earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                      dolorum eaque rem expedita inventore voluptas odit
+                      aspernatur alias molestias facere.
+                    </p>
+                  </Col>
+                </Row>
               ),
-              className: "u-align--right",
             },
-          ],
-          expanded: true,
-          expandedContent: (
-            <Row>
-              <Col size="8">
-                <h4>Expanding table cell</h4>
-                <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-                  Consequuntur cum dicta beatae nostrum eligendi similique
-                  earum, dolorem fuga quis, sequi voluptates architecto ipsa
-                  dolorum eaque rem expedita inventore voluptas odit aspernatur
-                  alias molestias facere.
-                </p>
-              </Col>
-            </Row>
-          ),
-        },
-        {
-          columns: [
-            { content: "Unknown", role: "rowheader" },
-            { content: "52:54:00:3a:fe:e9" },
-            { content: "172.16.99.191" },
-            { content: "karura" },
-            { content: "Wed, 3 Oct. 2018 23:08:06" },
             {
-              content: (
-                <button
-                  className="u-toggle"
-                  onClick={() =>
-                    setState({
-                      expandedRow: 2,
-                    })
-                  }
-                >
-                  Show
-                </button>
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "52:54:00:3a:fe:e9" },
+                { content: "172.16.99.191" },
+                { content: "karura" },
+                { content: "Wed, 3 Oct. 2018 23:08:06" },
+                {
+                  content: (
+                    <button
+                      className="u-toggle"
+                      onClick={() => setExpandedRow(2)}
+                    >
+                      Show
+                    </button>
+                  ),
+                  className: "u-align--right",
+                },
+              ],
+              expanded: expandedRow === 2,
+              expandedContent: (
+                <Row>
+                  <Col size="8">
+                    <h4>Expanding table cell</h4>
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                      Consequuntur cum dicta beatae nostrum eligendi similique
+                      earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                      dolorum eaque rem expedita inventore voluptas odit
+                      aspernatur alias molestias facere.
+                    </p>
+                  </Col>
+                </Row>
               ),
-              className: "u-align--right",
             },
-          ],
-          expanded: false,
-          expandedContent: (
-            <Row>
-              <Col size="8">
-                <h4>Expanding table cell</h4>
-                <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-                  Consequuntur cum dicta beatae nostrum eligendi similique
-                  earum, dolorem fuga quis, sequi voluptates architecto ipsa
-                  dolorum eaque rem expedita inventore voluptas odit aspernatur
-                  alias molestias facere.
-                </p>
-              </Col>
-            </Row>
-          ),
-        },
-        {
-          columns: [
-            { content: "Unknown", role: "rowheader" },
-            { content: "52:54:00:74:c2:10" },
-            { content: "172.16.99.192" },
-            { content: "karura" },
-            { content: "Wed, 17 Oct. 2018 12:18:18" },
             {
-              content: (
-                <button
-                  className="u-toggle"
-                  onClick={() =>
-                    setState({
-                      expandedRow: 3,
-                    })
-                  }
-                >
-                  Show
-                </button>
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "52:54:00:74:c2:10" },
+                { content: "172.16.99.192" },
+                { content: "karura" },
+                { content: "Wed, 17 Oct. 2018 12:18:18" },
+                {
+                  content: (
+                    <button
+                      className="u-toggle"
+                      onClick={() => setExpandedRow(3)}
+                    >
+                      Show
+                    </button>
+                  ),
+                  className: "u-align--right",
+                },
+              ],
+              expanded: expandedRow === 3,
+              expandedContent: (
+                <Row>
+                  <Col size="8">
+                    <h4>Expanding table cell</h4>
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                      Consequuntur cum dicta beatae nostrum eligendi similique
+                      earum, dolorem fuga quis, sequi voluptates architecto ipsa
+                      dolorum eaque rem expedita inventore voluptas odit
+                      aspernatur alias molestias facere.
+                    </p>
+                  </Col>
+                </Row>
               ),
-              className: "u-align--right",
             },
-          ],
-          expanded: false,
-          expandedContent: (
-            <Row>
-              <Col size="8">
-                <h4>Expanding table cell</h4>
-                <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-                  Consequuntur cum dicta beatae nostrum eligendi similique
-                  earum, dolorem fuga quis, sequi voluptates architecto ipsa
-                  dolorum eaque rem expedita inventore voluptas odit aspernatur
-                  alias molestias facere.
-                </p>
-              </Col>
-            </Row>
-          ),
-        },
-      ]}
-    />
+          ]}
+        />
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -13,14 +13,9 @@ describe("Table", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("can be sortable", () => {
-    const wrapper = shallow(<Table sortable={true} />);
-    expect(wrapper.prop("className").includes("p-table--sortable")).toBe(true);
-  });
-
   it("can be expanding", () => {
     const wrapper = shallow(<Table expanding={true} />);
-    expect(wrapper.prop("className").includes("p-table-expanding")).toBe(true);
+    expect(wrapper.prop("className").includes("p-table--expanding")).toBe(true);
   });
 
   it("can be responsive", () => {
@@ -31,9 +26,11 @@ describe("Table", () => {
   });
 
   it("can pass additional classes", () => {
-    const wrapper = shallow(<Table sortable={true} className="extra-class" />);
+    const wrapper = shallow(
+      <Table responsive={true} className="extra-class" />
+    );
     const className = wrapper.prop("className");
-    expect(className.includes("p-table--sortable")).toBe(true);
+    expect(className.includes("p-table--mobile-card")).toBe(true);
     expect(className.includes("extra-class")).toBe(true);
   });
 });

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -13,10 +13,6 @@ type Props = {
    * @defaultValue false
    */
   responsive?: boolean;
-  /**
-   * @defaultValue false
-   */
-  sortable?: boolean;
 } & HTMLProps<HTMLTableElement>;
 
 /**
@@ -38,15 +34,13 @@ const Table = ({
   className,
   expanding = false,
   responsive = false,
-  sortable = false,
   ...props
 }: Props): JSX.Element => (
   <table
     role="grid"
     className={classNames(className, {
       "p-table--mobile-card": responsive,
-      "p-table--sortable": sortable,
-      "p-table-expanding": expanding,
+      "p-table--expanding": expanding,
     })}
     {...props}
   >
@@ -59,7 +53,6 @@ Table.propTypes = {
   className: PropTypes.string,
   expanding: PropTypes.bool,
   responsive: PropTypes.bool,
-  sortable: PropTypes.bool,
 };
 
 export default Table;

--- a/src/components/TableCell/TableCell.test.tsx
+++ b/src/components/TableCell/TableCell.test.tsx
@@ -21,7 +21,7 @@ describe("TableCell", () => {
 
   it("can add be expanding", () => {
     const wrapper = shallow(<TableCell expanding={true} />);
-    expect(wrapper.prop("className").includes("p-table-expanding__panel")).toBe(
+    expect(wrapper.prop("className").includes("p-table__expanding-panel")).toBe(
       true
     );
   });
@@ -31,7 +31,7 @@ describe("TableCell", () => {
       <TableCell expanding={true} className="extra-class" />
     );
     const className = wrapper.prop("className");
-    expect(className.includes("p-table-expanding__panel")).toBe(true);
+    expect(className.includes("p-table__expanding-panel")).toBe(true);
     expect(className.includes("extra-class")).toBe(true);
   });
 });

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -45,7 +45,7 @@ const TableCell = ({
     role={role}
     aria-hidden={hidden}
     className={classNames(className, {
-      "p-table-expanding__panel": expanding,
+      "p-table__expanding-panel": expanding,
     })}
     {...props}
   >

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -20,11 +20,7 @@ type Props = {
  * @param sort - sort direction
  * @returns TableHeader
  */
-const TableHeader = ({
-  children,
-  sort = "none",
-  ...props
-}: Props): JSX.Element => {
+const TableHeader = ({ children, sort, ...props }: Props): JSX.Element => {
   return (
     <th role="columnheader" aria-sort={sort} {...props}>
       {children}

--- a/src/components/TableHeader/__snapshots__/TableHeader.test.tsx.snap
+++ b/src/components/TableHeader/__snapshots__/TableHeader.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`TableHeader renders 1`] = `
 <th
-  aria-sort="none"
   role="columnheader"
 >
   <tr />


### PR DESCRIPTION
## Done

- removed `aria-sort` from tables that are not sortable
- removed unused `p-table--sortable`
- renamed `p-table-expanding` to `p-table--expanding`
- driveby: added state to expanding table examples, fixes #269

Fixes: #405
Fixes: #269

## QA


### QA steps

- Check table storybook to see if there are no regressions
  - https://react-components-406.demos.haus/?path=/docs/maintable--default-story


### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```



