### PR TITLE
Update tooltip component to use new "is-detached" utility class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated SearchAndFilter, Modal and MainTable components to remove custom styling
 - Update to Vanilla v2.28.0-rc1
+- Updated Tooltip component with new `is-detached` utility class
 
 ### Removed
 

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -52,7 +52,7 @@ describe("<Tooltip />", () => {
     global.innerWidth = 20;
     wrapper.simulate("mouseover");
     expect(wrapper.find("[data-test='tooltip-portal']").prop("className")).toBe(
-      "p-tooltip--btm-left"
+      "p-tooltip--btm-left is-detached"
     );
   });
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -236,16 +236,13 @@ const Tooltip = ({
               <span
                 className={classNames(
                   `p-tooltip--${adjustedPosition}`,
+                  "is-detached",
                   tooltipClassName
                 )}
                 data-test="tooltip-portal"
                 style={positionStyle as React.CSSProperties}
               >
-                <span
-                  className="p-tooltip__message"
-                  ref={messageRef}
-                  style={{ display: "inline" }}
-                >
+                <span className="p-tooltip__message" ref={messageRef}>
                   {message}
                 </span>
               </span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14002,7 +14002,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@^2.28.0-rc1:
+vanilla-framework@2.28.0-rc1:
   version "2.28.0-rc1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.28.0-rc1.tgz#78a63e6115eac989a1c012f975771a504b59d275"
   integrity sha512-aXAGTSxaIevF2vjtWsZwvzm2xHBCi37JciXuEitPeealgTWoyuiTCQBOx9q5hx5axfuAhTBRI0vEWxBYKTMo4g==


### PR DESCRIPTION
## Done

- Removed inline `display: inline;` style from the tooltip components, and replaced it with the new `is-detached` utility class introduced by https://github.com/canonical-web-and-design/vanilla-framework/pull/3677

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open the storybook [tooltip example](https://react-components-426.demos.haus/?path=/story/tooltip--default-story)
- Hover over the button, see that the tooltip appears and behaves as expected (compare to [live version](https://canonical-web-and-design.github.io/react-components/?path=/story/tooltip--default-story), there should be no differences)

## Fixes

Fixes: https://github.com/canonical-web-and-design/vanilla-framework/issues/2672 .
