### PR TITLE
Add registry URL to release script

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build
       - run: yarn lint


### PR DESCRIPTION
## Done

Our current script fails (due to some auth/404 issue), according to [this thread](https://github.com/npm/cli/issues/1637) adding explicit registry URL should help (we do it in Vanilla as well).

