### PR TITLE
Add `content` prop to CodeSnippetBlock

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -120,6 +120,22 @@ exposeResult "Successful pre-deploy." 0 "true"`,
   </Story>
 </Canvas>
 
+### Bordered
+
+Set `bordered` prop to `true` to add a border around the entire code snippet.
+
+<Canvas>
+  <Story name="Bordered">
+    <CodeSnippet
+      blocks={[
+        { title: "JavaScript", code: "console.log('Vanilla');" },
+        { title: "Output", code: "Vanilla" },
+      ]}
+      bordered
+    />
+  </Story>
+</Canvas>
+
 ### Wrap lines
 
 Set `wrapLines` prop to `true` to enable line wrapping inside the code block.

--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -120,22 +120,6 @@ exposeResult "Successful pre-deploy." 0 "true"`,
   </Story>
 </Canvas>
 
-### Bordered
-
-Set `bordered` prop to `true` to add a border around the entire code snippet.
-
-<Canvas>
-  <Story name="Bordered">
-    <CodeSnippet
-      blocks={[
-        { title: "JavaScript", code: "console.log('Vanilla');" },
-        { title: "Output", code: "Vanilla" },
-      ]}
-      bordered
-    />
-  </Story>
-</Canvas>
-
 ### Wrap lines
 
 Set `wrapLines` prop to `true` to enable line wrapping inside the code block.
@@ -302,5 +286,31 @@ If multiple dropdowns may overlap with long title you can use `stacked` variant,
         />
       );
     }}
+  </Story>
+</Canvas>
+
+### Content
+
+Custom elements can be passed to a CodeBlock via the `content` prop.
+
+In these cases, it may be preferable to add a border around the entire code snippet to visually associate the content with the code block, which can be achieved by setting the CodeSnippet's `bordered` prop to `true`.
+
+<Canvas>
+  <Story name="Content">
+    <CodeSnippet
+      blocks={[
+        {
+          title: "With embedded iframe",
+          code:
+            "<iframe src='/iframe.html?id=button--base&viewMode=story'></iframe>",
+          content: (
+            <>
+              <iframe src="/iframe.html?id=button--base&viewMode=story"></iframe>
+            </>
+          ),
+        },
+      ]}
+      bordered
+    />
   </Story>
 </Canvas>

--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -291,9 +291,7 @@ If multiple dropdowns may overlap with long title you can use `stacked` variant,
 
 ### Content
 
-Custom elements can be passed to a CodeBlock via the `content` prop.
-
-In these cases, it may be preferable to add a border around the entire code snippet to visually associate the content with the code block, which can be achieved by setting the CodeSnippet's `bordered` prop to `true`.
+Custom elements can be passed to a CodeBlock via the `content` prop. In these cases, a border will be added around the entire code snippet to visually associate the content with the code block.
 
 <Canvas>
   <Story name="Content">
@@ -310,7 +308,6 @@ In these cases, it may be preferable to add a border around the entire code snip
           ),
         },
       ]}
-      bordered
     />
   </Story>
 </Canvas>

--- a/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -123,15 +123,9 @@ describe("CodeSnippet ", () => {
     expect(onChange).toHaveBeenCalled();
   });
 
-  it("renders code snippet with a border", () => {
-    const wrapper = mount(<CodeSnippet bordered blocks={[{ code: "Test" }]} />);
-    expect(wrapper.find(".p-code-snippet.is-bordered").length).toBe(1);
-  });
-
-  it("renders code snippet with a border", () => {
+  it("renders code snippets with a border when it also has custom content", () => {
     const wrapper = mount(
       <CodeSnippet
-        bordered
         blocks={[
           {
             code: "Test",
@@ -145,5 +139,6 @@ describe("CodeSnippet ", () => {
       />
     );
     expect(wrapper.find(".test").length).toBe(1);
+    expect(wrapper.find(".p-code-snippet.is-bordered").length).toBe(1);
   });
 });

--- a/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -127,4 +127,23 @@ describe("CodeSnippet ", () => {
     const wrapper = mount(<CodeSnippet bordered blocks={[{ code: "Test" }]} />);
     expect(wrapper.find(".p-code-snippet.is-bordered").length).toBe(1);
   });
+
+  it("renders code snippet with a border", () => {
+    const wrapper = mount(
+      <CodeSnippet
+        bordered
+        blocks={[
+          {
+            code: "Test",
+            content: (
+              <>
+                <span className="test"></span>
+              </>
+            ),
+          },
+        ]}
+      />
+    );
+    expect(wrapper.find(".test").length).toBe(1);
+  });
 });

--- a/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -122,4 +122,9 @@ describe("CodeSnippet ", () => {
     dropdowns.first().simulate("change");
     expect(onChange).toHaveBeenCalled();
   });
+
+  it("renders code snippet with a border", () => {
+    const wrapper = mount(<CodeSnippet bordered blocks={[{ code: "Test" }]} />);
+    expect(wrapper.find(".p-code-snippet.is-bordered").length).toBe(1);
+  });
 });

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -36,5 +36,6 @@ export default function CodeSnippet({
 
 CodeSnippet.propTypes = {
   blocks: PropTypes.array.isRequired,
+  bordered: PropTypes.bool,
   className: PropTypes.string,
 };

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -8,19 +8,14 @@ import type { CodeSnippetBlockProps } from "./CodeSnippetBlock";
 export type Props = {
   className?: string;
   blocks: CodeSnippetBlockProps[];
-  bordered?: boolean;
 };
 
-export default function CodeSnippet({
-  className,
-  blocks,
-  bordered,
-}: Props): JSX.Element {
+export default function CodeSnippet({ className, blocks }: Props): JSX.Element {
   return (
     <div
       className={classNames(
         "p-code-snippet",
-        { "is-bordered": bordered },
+        { "is-bordered": blocks.some((block) => block.content) },
         className
       )}
     >
@@ -36,6 +31,5 @@ export default function CodeSnippet({
 
 CodeSnippet.propTypes = {
   blocks: PropTypes.array.isRequired,
-  bordered: PropTypes.bool,
   className: PropTypes.string,
 };

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -8,11 +8,22 @@ import type { CodeSnippetBlockProps } from "./CodeSnippetBlock";
 export type Props = {
   className?: string;
   blocks: CodeSnippetBlockProps[];
+  bordered?: boolean;
 };
 
-export default function CodeSnippet({ className, blocks }: Props): JSX.Element {
+export default function CodeSnippet({
+  className,
+  blocks,
+  bordered,
+}: Props): JSX.Element {
   return (
-    <div className={classNames("p-code-snippet", className)}>
+    <div
+      className={classNames(
+        "p-code-snippet",
+        { "is-bordered": bordered },
+        className
+      )}
+    >
       {blocks.map((props, i) => (
         <CodeSnippetBlock
           key={`code-snippet-block-${i}`}

--- a/src/components/CodeSnippet/CodeSnippetBlock.tsx
+++ b/src/components/CodeSnippet/CodeSnippetBlock.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
+import type { ReactNode } from "react";
 
 import CodeSnippetDropdown from "./CodeSnippetDropdown";
 import type { CodeSnippetDropdownProps } from "./CodeSnippetDropdown";
@@ -19,6 +20,7 @@ export type CodeSnippetBlockProps = {
   wrapLines?: boolean;
   dropdowns?: CodeSnippetDropdownProps[];
   stacked?: boolean;
+  content?: ReactNode;
 };
 
 export default function CodeSnippetBlock({
@@ -28,6 +30,7 @@ export default function CodeSnippetBlock({
   wrapLines = false,
   dropdowns,
   stacked = false,
+  content,
 }: CodeSnippetBlockProps): JSX.Element {
   let className = "p-code-snippet__block";
   const isNumbered = appearance === CodeSnippetBlockAppearance.NUMBERED;
@@ -83,6 +86,7 @@ export default function CodeSnippetBlock({
       <pre className={className}>
         <code>{isNumbered ? numberedCode : code}</code>
       </pre>
+      {content}
     </>
   );
 }
@@ -99,4 +103,5 @@ CodeSnippetBlock.props = {
   wrapLines: PropTypes.bool,
   dropdowns: PropTypes.array,
   stacked: PropTypes.bool,
+  content: PropTypes.node,
 };


### PR DESCRIPTION
## Done

- Added `content` prop to CodeSnippetBlock, allowing custom elements (like iframes) to be included in a snippet.
- Updated CodeSnippet to add a border when the `content` prop has been set on a block

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open [demo](https://react-components-434.demos.haus/?path=/docs/codesnippet--content)
- See that the code snippet has a border and an iframe
- See that CI tests pass

## Fixes

Fixes: #419  .
