### PR TITLE
Update Code component to use CodeSnippet

### DIFF
--- a/src/components/Code/Code.js
+++ b/src/components/Code/Code.js
@@ -1,6 +1,7 @@
-import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useRef } from "react";
+import React from "react";
+
+import CodeSnippet, { CodeSnippetBlockAppearance } from "../CodeSnippet";
 
 /**
  * @deprecated Code component is deprecated. Use CodeSnippet component or inline `<code>` instead.
@@ -13,53 +14,29 @@ const Code = ({
   numbered,
   ...props
 }) => {
-  const input = useRef(null);
   if (inline) {
     return (
       <code className={className} {...props}>
         {children}
       </code>
     );
-  } else if (copyable) {
-    const handleClick = (evt) => {
-      input.current.focus();
-      input.current.select();
-      try {
-        document.execCommand("copy");
-      } catch (err) {
-        console.error("Copy was unsuccessful");
-      }
-    };
-    return (
-      <div className={classNames(className, "p-code-copyable")} {...props}>
-        <input
-          className="p-code-copyable__input"
-          readOnly="readonly"
-          ref={input}
-          value={children}
-        />
-        <button className="p-code-copyable__action" onClick={handleClick}>
-          Copy to clipboard
-        </button>
-      </div>
-    );
-  } else if (numbered) {
-    const lines = children.split(/\r?\n/);
-    const content = lines.map((line, i) => (
-      <span className="p-code-numbered__line" key={i}>
-        {line}
-      </span>
-    ));
-    return (
-      <pre className={classNames(className, "p-code-numbered")} {...props}>
-        <code>{content}</code>
-      </pre>
-    );
   } else {
+    let appearance = null;
+
+    if (numbered) {
+      appearance = CodeSnippetBlockAppearance.NUMBERED;
+    } else if (copyable) {
+      appearance = CodeSnippetBlockAppearance.LINUX_PROMPT;
+    }
     return (
-      <pre className={className} {...props}>
-        <code>{children}</code>
-      </pre>
+      <CodeSnippet
+        blocks={[
+          {
+            appearance,
+            code: children,
+          },
+        ]}
+      />
     );
   }
 };

--- a/src/components/Code/Code.stories.mdx
+++ b/src/components/Code/Code.stories.mdx
@@ -20,7 +20,9 @@ export const Template = (args) => <Code {...args} />;
 
 <div class="p-notification--caution">
   <div class="p-notification__response" role="status">
-    <span class="p-notification__status">Deprecated:</span><code>Code</code> component is deprecated. Use <code>CodeSnippet</code> component or inline <code>&lt;code&gt;</code> instead.
+    <span class="p-notification__status">Deprecated:</span>
+    <code>Code</code> component is deprecated. Use <code>CodeSnippet</code> component
+    or inline <code>&lt;code&gt;</code> instead.
   </div>
 </div>
 
@@ -76,12 +78,15 @@ Vanilla gives you multiple ways to display code using the standard HTML elements
 <Canvas>
   <Story name="Numbered">
     <Code numbered>
-      #!/bin/bash set -eu . $CONJURE_UP_SPELLSDIR/sdk/common.sh if [[
-      "$JUJU_PROVIDERTYPE" == "lxd" ]]; then debug "Running pre-deploy for
-      $CONJURE_UP_SPELL" sed "s/##MODEL##/$JUJU_MODEL/"
-      $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" ||
-      exposeResult "Failed to set profile" $? "false" fi exposeResult
-      "Successful pre-deploy." 0 "true"
+      {`#!/bin/bash
+set -eu
+. $CONJURE_UP_SPELLSDIR/sdk/common.sh
+if [["$JUJU_PROVIDERTYPE" == "lxd"]]; then
+    debug "Running pre-deploy for $CONJURE_UP_SPELL"
+    sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" ||
+    exposeResult "Failed to set profile" $? "false"
+fi
+exposeResult "Successful pre-deploy." 0 "true"`}
     </Code>
   </Story>
 </Canvas>

--- a/src/components/Code/__snapshots__/Code.test.js.snap
+++ b/src/components/Code/__snapshots__/Code.test.js.snap
@@ -1,29 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Code  can render 1`] = `
-<pre>
-  <code>
-    Test content
-  </code>
-</pre>
+<CodeSnippet
+  blocks={
+    Array [
+      Object {
+        "appearance": null,
+        "code": "Test content",
+      },
+    ]
+  }
+/>
 `;
 
 exports[`Code  can render as copyable 1`] = `
-<div
-  className="p-code-copyable"
->
-  <input
-    className="p-code-copyable__input"
-    readOnly="readonly"
-    value="Test content"
-  />
-  <button
-    className="p-code-copyable__action"
-    onClick={[Function]}
-  >
-    Copy to clipboard
-  </button>
-</div>
+<CodeSnippet
+  blocks={
+    Array [
+      Object {
+        "appearance": "linuxPrompt",
+        "code": "Test content",
+      },
+    ]
+  }
+/>
 `;
 
 exports[`Code  can render inline 1`] = `
@@ -33,16 +33,14 @@ exports[`Code  can render inline 1`] = `
 `;
 
 exports[`Code  can render with line numbers 1`] = `
-<pre
-  className="p-code-numbered"
->
-  <code>
-    <span
-      className="p-code-numbered__line"
-      key="0"
-    >
-      Test content
-    </span>
-  </code>
-</pre>
+<CodeSnippet
+  blocks={
+    Array [
+      Object {
+        "appearance": "numbered",
+        "code": "Test content",
+      },
+    ]
+  }
+/>
 `;


### PR DESCRIPTION
## Done

- Update deprecated `Code` component to use `CodeSnippet` internally while keeping the legacy component API

Fixes: #372

## QA

### QA steps

- Open storybook for Code component: https://react-components-435.demos.haus/?path=/docs/code--default-story
- Make sure examples render as expected
- Make sure examples render CodeSnippet `p-code-snippet` instead of deprecated `p-code-numbered` or `p-code-copyable`

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```



