### PR TITLE
Add dark theme option to the ContextualMenu component

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.stories.mdx
+++ b/src/components/ContextualMenu/ContextualMenu.stories.mdx
@@ -1,4 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import { useState } from "react";
 
 import ContextualMenu from "./ContextualMenu";
 
@@ -19,12 +20,6 @@ import ContextualMenu from "./ContextualMenu";
   }}
 />
 
-export const Template = (args) => (
-  <div className="u-align--center">
-    <ContextualMenu {...args} />
-  </div>
-);
-
 ### Contextual Menu
 
 This is a [React](https://reactjs.org/) component for the Vanilla [Contextual menu](https://docs.vanillaframework.io/patterns//contextual-menu/).
@@ -40,41 +35,63 @@ A contextual menu can be used in conjunction with any page element to provide a 
 The contextual menu will provide a visual wrapper to any provided children. Visibility can be toggled via the `visible` prop.
 
 <Canvas>
-  <Story
-    name="Default"
-    args={{
-      children: <span style={{ padding: "1rem" }}>This is a menu.</span>,
-      closeOnOutsideClick: false,
-      constrainPanelWidth: false,
-      position: "left",
-      visible: true,
-    }}
-  >
-    {Template.bind({})}
+  <Story name="Default">
+    <div className="u-align--center">
+      <ContextualMenu
+        closeOnOutsideClick={false}
+        constrainPanelWidth={false}
+        position="left"
+        visible
+      >
+        <span style={{ padding: "1rem" }}>This is a menu.</span>
+      </ContextualMenu>
+    </div>
   </Story>
 </Canvas>
 
 ### Toggle
 
 <Canvas>
-  <Story
-    name="Toggle"
-    args={{
-      links: [
-        {
-          children: "Link 1",
-          onClick: () => {},
-        },
-        {
-          children: "Link 2",
-          onClick: () => {},
-        },
-      ],
-      hasToggleIcon: true,
-      position: "right",
-      toggleLabel: "Click me!",
-    }}
-  >
-    {Template.bind({})}
+  <Story name="Toggle">
+    <div className="u-align--center">
+      <ContextualMenu
+        links={[
+          {
+            children: "Link 1",
+            onClick: () => {},
+          },
+          {
+            children: "Link 2",
+            onClick: () => {},
+          },
+        ]}
+        hasToggleIcon
+        position="right"
+        toggleLabel="Click me!"
+      />
+    </div>
+  </Story>
+</Canvas>
+
+### Dark
+
+Set `dark` prop to `true` to use the dark theme of the contextual menu dropdown.
+
+<Canvas>
+  <Story name="Dark">
+    <div className="u-align--center">
+      <ContextualMenu
+        closeOnOutsideClick={false}
+        constrainPanelWidth={false}
+        position="left"
+        toggleLabel="Toggle dark menu"
+        visible
+        dark
+      >
+        <a href="#" className="p-contextual-menu__link">
+          This is a menu.
+        </a>
+      </ContextualMenu>
+    </div>
   </Story>
 </Canvas>

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -21,6 +21,7 @@ export type Props<L> = {
   closeOnEsc?: boolean;
   closeOnOutsideClick?: boolean;
   constrainPanelWidth?: boolean;
+  dark?: boolean;
   dropdownClassName?: string;
   hasToggleIcon?: boolean;
   links?: MenuLink<L>[];
@@ -95,6 +96,7 @@ const ContextualMenu = <L,>({
   closeOnEsc = true,
   closeOnOutsideClick = true,
   constrainPanelWidth,
+  dark = false,
   dropdownClassName,
   hasToggleIcon,
   links,
@@ -142,6 +144,7 @@ const ContextualMenu = <L,>({
   const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
   const wrapperClass = classNames(className, "p-contextual-menu", {
     [`p-contextual-menu--${adjustedPosition}`]: adjustedPosition !== "right",
+    "is-dark": dark,
   });
 
   // Update the coordinates of the wrapper once it mounts to the dom. This uses
@@ -289,6 +292,10 @@ ContextualMenu.propTypes = {
    * Whether the menu's width should match the toggle's width.
    */
   constrainPanelWidth: PropTypes.bool,
+  /**
+   * Whether the menu should use the dark theme
+   */
+  dark: PropTypes.bool,
   /**
    * An optional class to apply to the dropdown.
    */


### PR DESCRIPTION
## Done

- Add `dark` prop to ContextualMenu to turn on dark theme

## QA

### QA steps

- Check dark example for contextual menu, make sure it renders as expected:
  - https://react-components-442.demos.haus/?path=/docs/contextualmenu--default-story#dark

## Fixes

Fixes: #415 


### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

