### PR TITLE
Fix handling of falsy values in keys in MainTable

### DIFF
--- a/src/components/MainTable/MainTable.js
+++ b/src/components/MainTable/MainTable.js
@@ -126,10 +126,16 @@ const generateRows = (
           {content}
         </TableCell>
       ));
+
+      // if key was not provided as a prop, use row's index instead
+      if (key === null || typeof key === "undefined") {
+        key = index;
+      }
+
       // The expanding cell is alway created to match the correct number of
       // table cells in rows that do have expanding content.
       return (
-        <TableRow key={key || index} {...rowProps}>
+        <TableRow key={key} {...rowProps}>
           {cellItems}
           {expanding && (
             <TableCell expanding={true} hidden={!expanded}>

--- a/src/components/MainTable/MainTable.test.js
+++ b/src/components/MainTable/MainTable.test.js
@@ -48,6 +48,18 @@ describe("MainTable", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("renders rows with provided keys", () => {
+    rows[0].key = 2;
+    rows[1].key = 1;
+    rows[2].key = 0; // we explicitly want to test 0 as a falsy value provided as a key
+
+    const wrapper = shallow(<MainTable headers={headers} rows={rows} />);
+
+    expect(wrapper.find("tbody TableRow").at(0).key()).toBe("2");
+    expect(wrapper.find("tbody TableRow").at(1).key()).toBe("1");
+    expect(wrapper.find("tbody TableRow").at(2).key()).toBe("0");
+  });
+
   it("can be expanding", () => {
     rows.push({
       columns: [


### PR DESCRIPTION
## Done

- Fixes how falsy keys are handled in MainTable

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Tests should pass

## Fixes

Fixes: #476
