### PR TITLE
Allow overflowing content in table cells

### DIFF
--- a/src/components/MainTable/MainTable.stories.mdx
+++ b/src/components/MainTable/MainTable.stories.mdx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import MainTable from "./MainTable";
 import Row from "../Row";
 import Col from "../Col";
+import ContextualMenu from "../ContextualMenu";
 
 <Meta
   title="MainTable"
@@ -257,6 +258,119 @@ This is a [React](https://reactjs.org/) component to support many table use case
                   </Col>
                 </Row>
               ),
+            },
+          ]}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Overflow
+
+If the table cell may have overflowing content (such as contextual menu) use `hasOverflow` prop to avoid cropping it.
+
+<Canvas>
+  <Story name="Overflow">
+    {() => {
+      let [expandedRow, setExpandedRow] = useState(1);
+      return (
+        <MainTable
+          headers={[
+            { content: "Name" },
+            { content: "Mac address" },
+            { content: "IP" },
+            { content: "Rack" },
+            { content: "Last seen" },
+            { content: "Actions", className: "u-align--right" },
+          ]}
+          rows={[
+            {
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "2c:44:fd:80:3f:25" },
+                { content: "10.249.0.1" },
+                { content: "karura" },
+                { content: "Thu, 25 Oct. 2018 13:55:21" },
+                {
+                  content: (
+                    <ContextualMenu
+                      links={[
+                        {
+                          children: "Link 1",
+                          onClick: () => {},
+                        },
+                        {
+                          children: "Link 2",
+                          onClick: () => {},
+                        },
+                      ]}
+                      hasToggleIcon
+                      position="right"
+                    />
+                  ),
+                  className: "u-align--right",
+                  hasOverflow: true,
+                },
+              ],
+            },
+            {
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "52:54:00:3a:fe:e9" },
+                { content: "172.16.99.191" },
+                { content: "karura" },
+                { content: "Wed, 3 Oct. 2018 23:08:06" },
+                {
+                  content: (
+                    <ContextualMenu
+                      links={[
+                        {
+                          children: "Link 1",
+                          onClick: () => {},
+                        },
+                        {
+                          children: "Link 2",
+                          onClick: () => {},
+                        },
+                      ]}
+                      hasToggleIcon
+                      position="right"
+                    />
+                  ),
+                  className: "u-align--right",
+                  hasOverflow: true,
+                },
+              ],
+            },
+            {
+              columns: [
+                { content: "Unknown", role: "rowheader" },
+                { content: "52:54:00:74:c2:10" },
+                { content: "172.16.99.192" },
+                { content: "karura" },
+                { content: "Wed, 17 Oct. 2018 12:18:18" },
+                {
+                  content: (
+                    <ContextualMenu
+                      links={[
+                        {
+                          children: "Link 1",
+                          onClick: () => {},
+                        },
+                        {
+                          children: "Link 2",
+                          onClick: () => {},
+                        },
+                      ]}
+                      hasToggleIcon
+                      position="right"
+                    />
+                  ),
+                  className: "u-align--right",
+                  hasOverflow: true,
+                },
+              ],
             },
           ]}
         />

--- a/src/components/TableCell/TableCell.test.tsx
+++ b/src/components/TableCell/TableCell.test.tsx
@@ -19,11 +19,16 @@ describe("TableCell", () => {
     expect(wrapper.prop("aria-hidden")).toBe(true);
   });
 
-  it("can add be expanding", () => {
+  it("can be expanding", () => {
     const wrapper = shallow(<TableCell expanding={true} />);
     expect(wrapper.prop("className").includes("p-table__expanding-panel")).toBe(
       true
     );
+  });
+
+  it("can have overflow", () => {
+    const wrapper = shallow(<TableCell hasOverflow={true} />);
+    expect(wrapper.prop("className").includes("has-overflow")).toBe(true);
   });
 
   it("can add additional classes", () => {

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -8,6 +8,10 @@ type Props = {
   /**
    * @defaultValue false
    */
+  hasOverflow?: boolean;
+  /**
+   * @defaultValue false
+   */
   expanding?: boolean;
   /**
    * @defaultValue false
@@ -36,6 +40,7 @@ type Props = {
 const TableCell = ({
   children,
   className,
+  hasOverflow = false,
   expanding = false,
   hidden = false,
   role = "gridcell",
@@ -46,6 +51,7 @@ const TableCell = ({
     aria-hidden={hidden}
     className={classNames(className, {
       "p-table__expanding-panel": expanding,
+      "has-overflow": hasOverflow,
     })}
     {...props}
   >


### PR DESCRIPTION
## Done

- Adds support for `has-overflow` in table cells

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open demo https://react-components-498.demos.haus/?path=/docs/maintable--default-story#overflow
- Make sure contextual menus work well in table cells with overflow option

<img width="1097" alt="Screenshot 2021-07-05 at 15 16 41" src="https://user-images.githubusercontent.com/83575/124477227-0f89db80-dda4-11eb-9177-4024e6a7eca8.png">
