### PR TITLE
Spread HTML props to Icon component

### DIFF
--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -18,4 +18,10 @@ describe("Icon", () => {
     const wrapper = shallow(<Icon className="custom-class" name="test" />);
     expect(wrapper.prop("className")).toBe("custom-class p-icon--test");
   });
+
+  it("can be given standard HTML props", () => {
+    const style = { width: "200px" };
+    const wrapper = shallow(<Icon name="test" style={style} />);
+    expect(wrapper.prop("style")).toBe(style);
+  });
 });

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
+import type { HTMLProps } from "react";
 import React from "react";
 
 export enum ICONS {
@@ -31,7 +32,7 @@ export enum ICONS {
 type Props = {
   className?: string;
   name: ICONS | string;
-};
+} & HTMLProps<HTMLElement>;
 
 /**
  * Icon
@@ -39,8 +40,8 @@ type Props = {
  * @param name One of built-in Vanilla icons or a name of a custom icon that follows `p-icon--{name}` convention.
  * @returns Icon
  */
-const Icon = ({ className, name }: Props): JSX.Element => (
-  <i className={classNames(className, `p-icon--${name}`)} />
+const Icon = ({ className, name, ...props }: Props): JSX.Element => (
+  <i className={classNames(className, `p-icon--${name}`)} {...props} />
 );
 
 Icon.propTypes = {


### PR DESCRIPTION
## Done

- Added HTML props support to Icon component. I've used the `HTMLElement` generic because there isn't a dedicated one for `<i>` tags, but in other places (e.g. `JSX.IntrinsicElements["i"]`) they just use `HTMLElement` under the hood.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- N/A - tests should pass

## Fixes

Fixes #492 