### PR TITLE
Show prop descriptions for typescript files

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,7 +8,43 @@ import type {
   AccordionSectionProps,
 } from "../AccordionSection";
 
-type Section = AccordionSectionProps & { key?: string | number };
+export type Section = AccordionSectionProps & {
+  /**
+   * An optional key for the section component. It will also be
+   * used to track which section is selected.
+   */
+  key?: string | number;
+};
+
+export type Props = {
+  /**
+   * Optional classes applied to the parent element.
+   */
+  className?: string;
+  /**
+   * An optional value to set the expanded section. The value must match a
+   * section key. This value will only set the expanded section on first render
+   * if externallyControlled is not set to `true`.
+   */
+  expanded?: string;
+  /**
+   * Whether the expanded section will be controlled via external state.
+   */
+  externallyControlled?: boolean;
+  /**
+   * Optional function that is called when the expanded section is changed.
+   * The function is provided the section title or null.
+   */
+  onExpandedChange?: (id, title: string) => void;
+  /**
+   * An array of sections and content.
+   */
+  sections: Section[];
+  /**
+   * Optional string describing heading element that should be used for the section titles.
+   */
+  titleElement?: AccordionHeadings;
+} & HTMLProps<HTMLElement>;
 
 const generateSections = (
   sections: Section[],
@@ -26,15 +62,6 @@ const generateSections = (
       {...props}
     />
   ));
-
-type Props = {
-  sections: Section[];
-  className?: string;
-  expanded?: string;
-  externallyControlled?: boolean;
-  onExpandedChange?: (id, title: string) => void;
-  titleElement?: AccordionHeadings;
-} & HTMLProps<HTMLElement>;
 
 const Accordion = ({
   className,

--- a/src/components/AccordionSection/AccordionSection.tsx
+++ b/src/components/AccordionSection/AccordionSection.tsx
@@ -8,14 +8,33 @@ import type { Headings } from "types";
 export type AccordionHeadings = Exclude<Headings, "h1">;
 
 export type Props = {
+  /**
+   * The content of the section.
+   */
   content?: ReactNode;
+  /**
+   * An optional value to set the expanded section. The value must match a
+   * section key.
+   */
   expanded?: string;
+  headingLevel?: number;
+  /**
+   * An optional click event when the title is clicked.
+   */
   onTitleClick?: (expanded: boolean, key: string) => void;
+  /**
+   * An optional key to be used to track which section is selected.
+   */
   sectionKey?: string;
   setExpanded?: (key: string | null, title: string | null) => void;
+  /**
+   * The title of the section.
+   */
   title?: string;
+  /**
+   * Optional string describing heading element that should be used for the section titles.
+   */
   titleElement?: AccordionHeadings;
-  headingLevel?: number;
 };
 
 const AccordionSection = ({

--- a/src/components/CheckableInput/CheckableInput.tsx
+++ b/src/components/CheckableInput/CheckableInput.tsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useRef, HTMLProps } from "react";
 import type { ReactNode } from "react";
 
-type Props = {
+export type Props = {
   inputType: "radio" | "checkbox";
   label: ReactNode;
   indeterminate?: boolean;

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import CheckableInput from "../CheckableInput";
 
-type Props = {
+export type Props = {
   label: ReactNode;
   indeterminate?: boolean;
 } & HTMLProps<HTMLInputElement>;

--- a/src/components/CodeSnippet/CodeSnippetDropdown.tsx
+++ b/src/components/CodeSnippet/CodeSnippetDropdown.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps } from "react";
 
-type DropdownOptionProps = {
+export type DropdownOptionProps = {
   label: string;
 } & HTMLProps<HTMLOptionElement>;
 

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -15,23 +15,77 @@ import type { MenuLink, Position } from "./ContextualMenuDropdown";
  * @template L - The type of the link props.
  */
 export type Props<L> = {
+  /**
+   * Whether the menu should adjust to fit in the screen.
+   */
   autoAdjust?: boolean;
+  /**
+   * The menu content (if the links prop is not supplied).
+   */
   children?: ReactNode;
+  /**
+   * An optional class to apply to the wrapping element.
+   */
   className?: string;
+  /**
+   * Whether the menu should close when the escape key is pressed.
+   */
   closeOnEsc?: boolean;
+  /**
+   * Whether the menu should close when clicking outside the menu.
+   */
   closeOnOutsideClick?: boolean;
+  /**
+   * Whether the menu's width should match the toggle's width.
+   */
   constrainPanelWidth?: boolean;
+  /**
+   * An optional class to apply to the dropdown.
+   */
   dropdownClassName?: string;
+  /**
+   * Whether the toggle should display a chevron icon.
+   */
   hasToggleIcon?: boolean;
+  /**
+   * A list of links to display in the menu (if the children prop is not supplied.)
+   */
   links?: MenuLink<L>[];
+  /**
+   * A function to call when the menu is toggled.
+   */
   onToggleMenu?: (isOpen: boolean) => void;
+  /**
+   * The position of the menu.
+   */
   position?: Position;
+  /**
+   * An element to make the menu relative to.
+   */
   positionNode?: HTMLElement;
+  /**
+   * The appearance of the toggle button.
+   */
   toggleAppearance?: string;
+  /**
+   * A class to apply to the toggle button.
+   */
   toggleClassName?: string;
+  /**
+   * Whether the toggle button should be disabled.
+   */
   toggleDisabled?: boolean;
+  /**
+   * The toggle button's label.
+   */
   toggleLabel?: string;
+  /**
+   * Whether the toggle lable or icon should appear first.
+   */
   toggleLabelFirst?: boolean;
+  /**
+   * Whether the menu should be visible.
+   */
   visible?: boolean;
 };
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -29,7 +29,7 @@ export enum ICONS {
   error = "error",
 }
 
-type Props = {
+export type Props = {
   className?: string;
   name: ICONS | string;
 } & HTMLProps<HTMLElement>;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import { nanoid } from "nanoid";
 import PropTypes from "prop-types";
 import React, { ReactElement, ReactNode, useRef, useEffect } from "react";
 
-type Props = {
+export type Props = {
   buttonRow?: ReactNode | null;
   children: ReactNode;
   close?: () => void | null;

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -91,7 +91,7 @@ const PaginationItemSeparator = (): JSX.Element => (
   </li>
 );
 
-type Props = {
+export type Props = {
   currentPage: number;
   itemsPerPage: number;
   paginate: (page: number) => void;

--- a/src/components/PaginationButton/PaginationButton.tsx
+++ b/src/components/PaginationButton/PaginationButton.tsx
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import React from "react";
 import type { MouseEventHandler } from "react";
 
-type PaginationDirection = "forward" | "back";
-type Props = {
+export type PaginationDirection = "forward" | "back";
+export type Props = {
   direction: PaginationDirection;
   onClick: MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;

--- a/src/components/PaginationItem/PaginationItem.tsx
+++ b/src/components/PaginationItem/PaginationItem.tsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import type { MouseEventHandler } from "react";
 
-type Props = {
+export type Props = {
   number: number;
   onClick: MouseEventHandler<HTMLButtonElement>;
   isActive?: boolean;

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import CheckableInput from "../CheckableInput";
 
-type Props = {
+export type Props = {
   label: ReactNode;
 } & HTMLProps<HTMLInputElement>;
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -6,18 +6,54 @@ import Field from "../Field";
 
 export const FILLED_COLOR = "#0066CC";
 
-type Props = {
+export type Props = {
+  /**
+   * Field caution message.
+   */
   caution?: ReactNode;
+  /**
+   * Whether to disable the slider and input (if showInput is true).
+   */
   disabled?: boolean;
+  /**
+   * Field error message.
+   */
   error?: ReactNode;
-  id?: string;
+  /**
+   * Field help message.
+   */
   help?: ReactNode;
+  /**
+   * Field id. Only passed to range input, not to number input.
+   */
+  id?: string;
+  /**
+   * Whether to disable only the input, but not the slider.
+   */
   inputDisabled?: boolean;
+  /**
+   * Field label.
+   */
   label?: ReactNode;
+  /**
+   * Maximum value of the slider.
+   */
   max: number;
+  /**
+   * Minimum value of the slider.
+   */
   min: number;
+  /**
+   * Change event handler.
+   */
   onChange: ChangeEventHandler;
+  /**
+   * Whether the field is required for the form to submit.
+   */
   required?: boolean;
+  /**
+   * Whether to show a number input with the numerical value next to the slider.
+   */
   showInput?: boolean;
 } & HTMLProps<HTMLInputElement>;
 

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import classNames from "classnames";
 
-type Props = {
+export type Props = {
   className?: string;
   text?: string;
   isLight?: boolean;

--- a/src/components/SummaryButton/SummaryButton.tsx
+++ b/src/components/SummaryButton/SummaryButton.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 import ActionButton from "../ActionButton";
 
-type Props = {
+export type Props = {
   className?: string;
   label: string;
   onClick: (event: SyntheticEvent) => void;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
-type Props = {
+export type Props = {
   children?: ReactNode;
   className?: string;
   /**

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
-type Props = {
+export type Props = {
   children?: ReactNode;
   className?: string;
   /**

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
-type Props = {
+export type Props = {
   children: ReactNode;
   /**
    * @defaultValue none

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import type { HTMLProps, ReactNode } from "react";
 import React from "react";
 
-type Props = {
+export type Props = {
   children: ReactNode;
 } & HTMLProps<HTMLTableRowElement>;
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -4,16 +4,40 @@ import React from "react";
 import type { HTMLProps, ElementType, ReactNode, ComponentType } from "react";
 
 export type TabLink<P = null> = {
+  /**
+   * Whether the tab link should have active styling.
+   */
   active?: boolean;
+  /**
+   * Optional classes applied to the link element.
+   */
   className?: string;
+  /**
+   * Optional component to be used instead of the default "a" element.
+   */
   component?: ElementType | ComponentType<P>;
+  /**
+   * Label to be displayed inside the tab link.
+   */
   label: ReactNode;
+  /**
+   * Optional classes applied to the "li" element.
+   */
   listItemClassName?: string;
 } & (HTMLProps<HTMLElement> | P);
 
-type Props<P = null> = {
-  links: TabLink<P>[];
+export type Props<P = null> = {
+  /**
+   * Optional classes applied to the parent "nav" element.
+   */
   className?: string;
+  /**
+   * An array of tab link objects.
+   */
+  links: TabLink<P>[];
+  /**
+   * Optional classes applied to the "ul" element.
+   */
   listClassName?: string;
 };
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -17,9 +17,9 @@ export type CSSPosition =
   | "inherit";
 
 export type PositionStyle = {
+  left: number;
   pointerEvents?: string;
   position: CSSPosition;
-  left: number;
   top: number;
 };
 
@@ -34,13 +34,37 @@ export type Position =
   | "top-right";
 
 export type Props = {
+  /**
+   * Whether the tooltip should adjust to fit in the screen.
+   */
   autoAdjust?: boolean;
-  className?: string;
+  /**
+   * Element on which to apply the tooltip.
+   */
   children: ReactNode;
+  /**
+   * An optional class to apply to the wrapping element.
+   */
+  className?: string;
+  /**
+   * Whether the tooltip should follow the mouse.
+   */
   followMouse?: boolean;
+  /**
+   * Message to display when the element is hovered.
+   */
   message?: string | null;
+  /**
+   * Position of the tooltip relative to the element.
+   */
   position?: Position;
+  /**
+   * An optional class to apply to the element that wraps the children.
+   */
   positionElementClassName?: string;
+  /**
+   * An optional class to apply to the tooltip message element.
+   */
   tooltipClassName?: string;
 };
 


### PR DESCRIPTION
## Done

- Copy prop descriptions to type definitions.
- Export all prop types.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Visit the following pages and check that they have descriptions in the descriptions column:
  - [Accordion](url)
  - [ContextualMenu](url)
  - [Slider](url)
  - [Tabs](url)
  - [Tooltip](url)

## Fixes

Fixes: #274.
