### PR TITLE
Fix some syntax highlighting being unreadable

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,4 +6,8 @@
   .sbdocs-preview > div > div:last-child > button {
     margin-bottom: 0 !important;
   }
+
+  .prismjs {
+    color: unset;
+  }
 </style>


### PR DESCRIPTION
## Done

- Made default `prismjs` colour `unset`, which unsets Vanilla's default of black. I can't figure out why the syntax highlighting isn't properly working for stories that have an internal function for using hooks, but I think this is a bigger issue than just the syntax highlighting. For now at least the code is readable.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the MainTable - Expanding code block and check that there is no black text

## Fixes

Fixes #292 
