### PR TITLE
Bump version of Vanilla to 2.33.0-rc1 pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "stylelint-scss": "3.19.0",
     "ts-jest": "27.0.3",
     "typescript": "4.3.5",
-    "vanilla-framework": "2.32.0",
+    "vanilla-framework": "2.33.0-rc1",
     "wait-on": "5.3.0"
   },
   "dependencies": {
@@ -90,7 +90,7 @@
   "peerDependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "vanilla-framework": "2.32.0"
+    "vanilla-framework": "2.33.0-rc1"
   },
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files --extensions '.js,.jsx,.ts,.tsx'; yarn build-declaration",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4437,13 +4437,13 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@10.2.6:
-  version "10.2.6"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.2.6.tgz#aadd9ec34e1c98d403e01950038049f0eb252949"
-  integrity sha512-8lChSmdU6dCNMCQopIf4Pe5kipkAGj/fvTMslCsih0uHpOrXOPUEVOmYMMqmw3cekQkSD7EhIeuYl5y0BLdKqg==
+autoprefixer@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.3.0.tgz#c60803dce9268f7fe0a5e5c1fe48a74356d7b864"
+  integrity sha512-BzVzdjs47nT3MphTddr8eSsPVEIUCF96X6iC8V5iEB8RtxrU+ybtdhHV5rsqRqOsoyh/acQaYs7YupHPUECgmg==
   dependencies:
     browserslist "^4.16.6"
-    caniuse-lite "^1.0.30001230"
+    caniuse-lite "^1.0.30001243"
     colorette "^1.2.2"
     fraction.js "^4.1.1"
     normalize-range "^0.1.2"
@@ -5171,10 +5171,15 @@ caniuse-lite@^1.0.30001208:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
   integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
 
-caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001230:
+caniuse-lite@^1.0.30001219:
   version "1.0.30001235"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz#ad5ca75bc5a1f7b12df79ad806d715a43a5ac4ed"
   integrity sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==
+
+caniuse-lite@^1.0.30001243:
+  version "1.0.30001243"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz#d9250155c91e872186671c523f3ae50cfc94a3aa"
+  integrity sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -15029,14 +15034,14 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.32.0:
-  version "2.32.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.32.0.tgz#3462e2e6040488ca6da154e3f5e08dc07c4ba944"
-  integrity sha512-bKNZSyv09tl5pV+6Qj7KxAtkb2+IcQ6DWiU3uloL/Jhz1v83gThfwdJSZIhn+rduo/uBvnwP6jS+CWWO+uJmTg==
+vanilla-framework@^2.33.0-rc1:
+  version "2.33.0-rc1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.33.0-rc1.tgz#1b65fd5a231589521fb0236391d28ffc2608fff9"
+  integrity sha512-HJsWCJWTXq/FEf2c4fVz66Ma05lApYkBk+5X1CGEPg15BK3qz2tGf+VQiTj0JrsDhBfOR7d06cxIBOhF/n1Rjw==
   dependencies:
     "@canonical/cookie-policy" "3.2.0"
     "@canonical/latest-news" "1.2.0"
-    autoprefixer "10.2.6"
+    autoprefixer "10.3.0"
     node-sass "6.0.1"
     postcss "8.3.5"
     postcss-cli "8.3.1"


### PR DESCRIPTION
## Done

- Bump Vanilla to pre release that contains new notification styles for canonical-web-and-design/vanilla-framework#3818


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- demo: https://react-components-513.demos.haus/
- check notifications - https://react-components-513.demos.haus/?path=/docs/notification--default-story
  - they should have new style (legacy version of HTML)

