### PR TITLE
Graceful highlight

### DIFF
--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.js
@@ -8,7 +8,7 @@ const FilterPanelSection = ({
   data,
   toggleSelected,
   searchData,
-  searchTerm,
+  searchTerm = "",
   sectionHidden,
 }) => {
   const { chips, heading } = data;

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
@@ -10,16 +10,12 @@ const sampleData = {
 
 describe("Filter panel section", () => {
   it("renders", () => {
-    const wrapper = shallow(
-      <FilterPanelSection data={sampleData} searchTerm="" />
-    );
+    const wrapper = shallow(<FilterPanelSection data={sampleData} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("shows correct data passed as prop", () => {
-    const wrapper = mount(
-      <FilterPanelSection data={sampleData} searchTerm="" />
-    );
+    const wrapper = mount(<FilterPanelSection data={sampleData} />);
     expect(wrapper.find(".p-filter-panel-section").length).toEqual(1);
     const section = wrapper.find(".p-filter-panel-section");
     const chips = wrapper.find(".p-chip");
@@ -57,9 +53,7 @@ describe("Filter panel section", () => {
       configurable: true,
       value: 100,
     });
-    const wrapper = mount(
-      <FilterPanelSection data={sampleData} searchTerm="" />
-    );
+    const wrapper = mount(<FilterPanelSection data={sampleData} />);
     expect(wrapper.find(".p-filter-panel-section__counter").text()).toEqual(
       "+3"
     );
@@ -67,11 +61,7 @@ describe("Filter panel section", () => {
 
   it("all chips are shown when counter is clicked", () => {
     const wrapper = mount(
-      <FilterPanelSection
-        data={sampleData}
-        sectionHidden={false}
-        searchTerm=""
-      />
+      <FilterPanelSection data={sampleData} sectionHidden={false} />
     );
     expect(wrapper.find("[aria-expanded=false]").length).toEqual(1);
     wrapper.find(".p-filter-panel-section__counter").simulate("click");

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.js
@@ -10,12 +10,16 @@ const sampleData = {
 
 describe("Filter panel section", () => {
   it("renders", () => {
-    const wrapper = shallow(<FilterPanelSection data={sampleData} />);
+    const wrapper = shallow(
+      <FilterPanelSection data={sampleData} searchTerm="" />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it("shows correct data passed as prop", () => {
-    const wrapper = mount(<FilterPanelSection data={sampleData} />);
+    const wrapper = mount(
+      <FilterPanelSection data={sampleData} searchTerm="" />
+    );
     expect(wrapper.find(".p-filter-panel-section").length).toEqual(1);
     const section = wrapper.find(".p-filter-panel-section");
     const chips = wrapper.find(".p-chip");
@@ -53,7 +57,9 @@ describe("Filter panel section", () => {
       configurable: true,
       value: 100,
     });
-    const wrapper = mount(<FilterPanelSection data={sampleData} />);
+    const wrapper = mount(
+      <FilterPanelSection data={sampleData} searchTerm="" />
+    );
     expect(wrapper.find(".p-filter-panel-section__counter").text()).toEqual(
       "+3"
     );
@@ -61,7 +67,11 @@ describe("Filter panel section", () => {
 
   it("all chips are shown when counter is clicked", () => {
     const wrapper = mount(
-      <FilterPanelSection data={sampleData} sectionHidden={false} />
+      <FilterPanelSection
+        data={sampleData}
+        sectionHidden={false}
+        searchTerm=""
+      />
     );
     expect(wrapper.find("[aria-expanded=false]").length).toEqual(1);
     wrapper.find(".p-filter-panel-section__counter").simulate("click");

--- a/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
+++ b/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.js.snap
@@ -9,7 +9,7 @@ exports[`Filter panel section renders 1`] = `
       className="p-filter-panel-section__heading"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<strong></strong>R<strong></strong>e<strong></strong>g<strong></strong>i<strong></strong>o<strong></strong>n<strong></strong>s<strong></strong>",
+          "__html": "Regions",
         }
       }
     />
@@ -22,6 +22,7 @@ exports[`Filter panel section renders 1`] = `
       >
         <Chip
           onClick={[Function]}
+          subString=""
           value="us-east1"
         />
       </span>
@@ -30,6 +31,7 @@ exports[`Filter panel section renders 1`] = `
       >
         <Chip
           onClick={[Function]}
+          subString=""
           value="us-east2"
         />
       </span>
@@ -38,6 +40,7 @@ exports[`Filter panel section renders 1`] = `
       >
         <Chip
           onClick={[Function]}
+          subString=""
           value="us-east3"
         />
       </span>

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,12 @@ export const IS_DEV = process.env.NODE_ENV === "development";
  * @return {Obj} newStr - Object with text and match bool
  */
 export const highlightSubString = (str, subString) => {
+  if (typeof str !== "string" || typeof subString !== "string") {
+    return {
+      text: str || "",
+      match: false,
+    };
+  }
   const caseInsensitiveRegex = new RegExp(subString, "gi");
   const newStr = str.replace(
     caseInsensitiveRegex,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -7,4 +7,18 @@ describe("highlightSubString function ", () => {
     const testString = highlightSubString(string, subString);
     expect(testString).toEqual({ match: true, text: "re<strong>act</strong>" });
   });
+
+  it("gracefully fails when invalid string is provided", () => {
+    expect(highlightSubString(undefined, "somesub")).toEqual({
+      text: "",
+      match: false,
+    });
+  });
+
+  it("gracefully fails when invalid substring is provided", () => {
+    expect(highlightSubString("somestring", undefined)).toEqual({
+      text: "somestring",
+      match: false,
+    });
+  });
 });


### PR DESCRIPTION
## Done

A user reported that the search and filter component was causing the Juju Dashboard to crash because it was receiving invalid data. This makes the source of the problem, the `highlightSubString` function more resilient to bad data in an attempt to solve the issue.

## QA

### QA steps

- Use the search and filter UI, it should continue to work as normal

## Fixes

Fixes: #477 
