### PR TITLE
Replace the cloud key in Chip component

### DIFF
--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -41,4 +41,13 @@ describe("Chip ", () => {
     dismissButton.simulate("click");
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it("calls onKeyDown when key pressed", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(<Chip lead="Owner" value="Bob" onClick={onClick} />);
+    const chip = wrapper.find(".p-chip");
+    chip.simulate("keydown", { key: "Enter" });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0]).toEqual([{ lead: "Owner", value: "Bob" }]);
+  });
 });

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -29,7 +29,7 @@ const Chip = ({
   const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     // The " " value is what is returned for the spacebar
     if (e.key === " " || e.key === "Enter") {
-      if (onClick instanceof Function) {
+      if (typeof onClick === "function") {
         onClick({ lead: lead, value: value });
       }
     }

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -6,7 +6,7 @@ import type { KeyboardEvent, MouseEvent } from "react";
 export type Props = {
   lead?: string;
   onClick?: (
-    event: MouseEvent<HTMLDivElement> | { lead: string; cloud: string }
+    event: MouseEvent<HTMLDivElement> | { lead: string; value: string }
   ) => void;
   onDismiss?: () => void;
   selected?: boolean;
@@ -30,7 +30,7 @@ const Chip = ({
     // The " " value is what is returned for the spacebar
     if (e.key === " " || e.key === "Enter") {
       if (onClick instanceof Function) {
-        onClick({ lead: lead, cloud: value });
+        onClick({ lead: lead, value: value });
       }
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15034,7 +15034,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@^2.33.0-rc1:
+vanilla-framework@2.33.0-rc1:
   version "2.33.0-rc1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.33.0-rc1.tgz#1b65fd5a231589521fb0236391d28ffc2608fff9"
   integrity sha512-HJsWCJWTXq/FEf2c4fVz66Ma05lApYkBk+5X1CGEPg15BK3qz2tGf+VQiTj0JrsDhBfOR7d06cxIBOhF/n1Rjw==


### PR DESCRIPTION
## Done
- Replace the `cloud` on keyPress with `value` making this component generic

## QA
- Check the code

## Fixes
Fixes: https://github.com/canonical-web-and-design/react-components/issues/507
