### PR TITLE
Generate prop types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,8 @@
     "@babel/preset-react",
     "@babel/preset-typescript"
   ],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "babel-plugin-typescript-to-proptypes"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-eslint": "10.1.0",
     "babel-jest": "27.0.6",
     "babel-loader": "8.2.2",
+    "babel-plugin-typescript-to-proptypes": "1.4.2",
     "concurrently": "6.2.0",
     "css-loader": "5.2.6",
     "cypress": "7.6.0",

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { MOCK_UUID } from "../../setupTests";
 import Accordion from "./Accordion";
 
-describe("Accordion ", () => {
+describe("Accordion", () => {
   it("renders", () => {
     const wrapper = shallow(
       <Accordion

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useState, HTMLProps } from "react";
 
 import AccordionSection from "../AccordionSection";
@@ -94,56 +93,6 @@ const Accordion = ({
       </ul>
     </aside>
   );
-};
-
-Accordion.propTypes = {
-  /**
-   * Optional classes applied to the parent element.
-   */
-  className: PropTypes.string,
-  /**
-   * An optional value to set the expanded section. The value must match a
-   * section key. This value will only set the expanded section on first render
-   * if externallyControlled is not set to `true`.
-   */
-  expanded: PropTypes.string,
-  /**
-   * Whether the expanded section will be controlled via external state.
-   */
-  externallyControlled: PropTypes.bool,
-  /**
-   * An array of sections and content.
-   */
-  sections: PropTypes.arrayOf(
-    PropTypes.shape({
-      /**
-       * The content of the section.
-       */
-      content: PropTypes.node,
-      /**
-       * An optional key for the section component. It will also be
-       * used to track which section is selected.
-       */
-      key: PropTypes.string,
-      /**
-       * An optional click event when the title is clicked.
-       */
-      onTitleClick: PropTypes.func,
-      /**
-       * The title of the section.
-       */
-      title: PropTypes.string,
-    }).isRequired
-  ),
-  /**
-   * Optional function that is called when the expanded section is changed.
-   * The function is provided the section title or null.
-   */
-  onExpandedChange: PropTypes.func,
-  /**
-   * Optional string describing heading element that should be used for the section titles.
-   */
-  titleElement: PropTypes.oneOf(["h2", "h3", "h4", "h5", "h6"]),
 };
 
 export default Accordion;

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Accordion  renders 1`] = `
+exports[`Accordion renders 1`] = `
 <aside
   aria-multiselectable="true"
   className="p-accordion"

--- a/src/components/AccordionSection/AccordionSection.tsx
+++ b/src/components/AccordionSection/AccordionSection.tsx
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import PropTypes from "prop-types";
 import React, { useRef } from "react";
 import type { ReactNode } from "react";
 
@@ -88,23 +87,6 @@ const AccordionSection = ({
       </section>
     </li>
   );
-};
-
-AccordionSection.propTypes = {
-  content: PropTypes.node,
-  expanded: PropTypes.string,
-  /**
-   * An optional click event when the title is clicked.
-   */
-  onTitleClick: PropTypes.func,
-  /**
-   * An optional key to be used to track which section is selected.
-   */
-  sectionKey: PropTypes.string,
-  setExpanded: PropTypes.func,
-  title: PropTypes.string,
-  titleElement: PropTypes.oneOf(["h2", "h3", "h4", "h5", "h6"]),
-  headingLevel: PropTypes.oneOf([2, 3, 4, 5, 6]),
 };
 
 export default AccordionSection;

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef, useState } from "react";
 import type { HTMLAttributes, ReactNode } from "react";
 
@@ -141,16 +140,6 @@ const ActionButton = ({
       )}
     </button>
   );
-};
-
-ActionButton.propTypes = {
-  appearance: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  inline: PropTypes.bool,
-  loading: PropTypes.bool,
-  success: PropTypes.bool,
 };
 
 export default ActionButton;

--- a/src/components/ArticlePagination/ArticlePagination.tsx
+++ b/src/components/ArticlePagination/ArticlePagination.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps } from "react";
 
@@ -53,25 +52,6 @@ const ArticlePagination = ({
       )}
     </footer>
   );
-};
-
-ArticlePagination.propTypes = {
-  /**
-   * The URL for the next link.
-   */
-  nextURL: PropTypes.string,
-  /**
-   * The label for the next link.
-   */
-  nextLabel: PropTypes.string,
-  /**
-   * The URL for the previous link.
-   */
-  previousURL: PropTypes.string,
-  /**
-   * The label for the previous link.
-   */
-  previousLabel: PropTypes.string,
 };
 
 export default ArticlePagination;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps, ElementType, ReactNode, ComponentType } from "react";
 
@@ -103,19 +102,6 @@ const Button = <P,>({
       {children}
     </Component>
   );
-};
-
-Button.propTypes = {
-  appearance: PropTypes.string,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  dense: PropTypes.bool,
-  disabled: PropTypes.bool,
-  element: PropTypes.elementType,
-  hasIcon: PropTypes.bool,
-  inline: PropTypes.bool,
-  onClick: PropTypes.func,
-  small: PropTypes.bool,
 };
 
 export default Button;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { ReactNode } from "react";
 
 export type Props = {
@@ -56,14 +55,5 @@ const Card = ({
     <div className="p-card__content">{children}</div>
   </div>
 );
-
-Card.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  highlighted: PropTypes.bool,
-  overlay: PropTypes.bool,
-  title: PropTypes.node,
-  thumbnail: PropTypes.string,
-};
 
 export default Card;

--- a/src/components/CheckableInput/CheckableInput.tsx
+++ b/src/components/CheckableInput/CheckableInput.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import { nanoid } from "nanoid";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef, HTMLProps } from "react";
 import type { ReactNode } from "react";
 
@@ -50,12 +49,6 @@ const CheckableInput = ({
       </span>
     </label>
   );
-};
-
-CheckableInput.propTypes = {
-  inputType: PropTypes.oneOf(["checkbox", "radio"]).isRequired,
-  label: PropTypes.node.isRequired,
-  indeterminate: PropTypes.bool,
 };
 
 export default CheckableInput;

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { HTMLProps } from "react";
 import type { ReactNode } from "react";
 
@@ -28,11 +27,6 @@ const CheckboxInput = ({
       {...checkboxProps}
     ></CheckableInput>
   );
-};
-
-CheckboxInput.propTypes = {
-  label: PropTypes.node.isRequired,
-  indeterminate: PropTypes.bool,
 };
 
 export default CheckboxInput;

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { highlightSubString } from "../../utils";
 import type { KeyboardEvent, MouseEvent } from "react";
 
@@ -82,16 +81,6 @@ const Chip = ({
       ) : null}
     </div>
   );
-};
-
-Chip.propTypes = {
-  lead: PropTypes.string,
-  onClick: PropTypes.func,
-  onDismiss: PropTypes.func,
-  selected: PropTypes.bool,
-  subString: PropTypes.string,
-  quoteValue: PropTypes.bool,
-  value: PropTypes.string,
 };
 
 export default Chip;

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 
 import CodeSnippetBlock from "./CodeSnippetBlock";
@@ -34,8 +33,3 @@ export default function CodeSnippet({ className, blocks }: Props): JSX.Element {
     </div>
   );
 }
-
-CodeSnippet.propTypes = {
-  blocks: PropTypes.array.isRequired,
-  className: PropTypes.string,
-};

--- a/src/components/CodeSnippet/CodeSnippetBlock.tsx
+++ b/src/components/CodeSnippet/CodeSnippetBlock.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { ReactNode } from "react";
 
@@ -112,18 +111,3 @@ export default function CodeSnippetBlock({
     </>
   );
 }
-
-CodeSnippetBlock.props = {
-  code: PropTypes.string.isRequired,
-  title: PropTypes.string,
-  appearance: PropTypes.oneOf([
-    CodeSnippetBlockAppearance.NUMBERED,
-    CodeSnippetBlockAppearance.LINUX_PROMPT,
-    CodeSnippetBlockAppearance.WINDOWS_PROMPT,
-    CodeSnippetBlockAppearance.URL,
-  ]),
-  wrapLines: PropTypes.bool,
-  dropdowns: PropTypes.array,
-  stacked: PropTypes.bool,
-  content: PropTypes.node,
-};

--- a/src/components/CodeSnippet/CodeSnippetDropdown.tsx
+++ b/src/components/CodeSnippet/CodeSnippetDropdown.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import type { ChangeEventHandler, HTMLProps } from "react";
 
@@ -35,13 +34,3 @@ export default function CodeSnippetDropdown({
     </select>
   );
 }
-
-CodeSnippetDropdown.props = {
-  onChange: PropTypes.func.isRequired,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    })
-  ).isRequired,
-};

--- a/src/components/Col/Col.tsx
+++ b/src/components/Col/Col.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { ElementType, HTMLProps, ReactNode } from "react";
 
@@ -77,18 +76,5 @@ const Col = ({
     {children}
   </Component>
 );
-
-Col.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  element: PropTypes.string,
-  emptyLarge: PropTypes.oneOf(colSizes),
-  emptyMedium: PropTypes.oneOf(colSizes),
-  emptySmall: PropTypes.oneOf(colSizes),
-  large: PropTypes.oneOf(colSizes),
-  medium: PropTypes.oneOf(colSizes),
-  size: PropTypes.oneOf(colSizes).isRequired,
-  small: PropTypes.oneOf(colSizes),
-};
 
 export default Col;

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -1,6 +1,5 @@
 import { nanoid } from "nanoid";
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import usePortal from "react-useportal";
@@ -317,87 +316,6 @@ const ContextualMenu = <L,>({
       )}
     </span>
   );
-};
-
-ContextualMenu.propTypes = {
-  /**
-   * Whether the menu should adjust to fit in the screen.
-   */
-  autoAdjust: PropTypes.bool,
-  /**
-   * The menu content (if the links prop is not supplied).
-   */
-  children: PropTypes.node,
-  /**
-   * An optional class to apply to the wrapping element.
-   */
-  className: PropTypes.string,
-  /**
-   * Whether the menu should close when the escape key is pressed.
-   */
-  closeOnEsc: PropTypes.bool,
-  /**
-   * Whether the menu should close when clicking outside the menu.
-   */
-  closeOnOutsideClick: PropTypes.bool,
-  /**
-   * Whether the menu's width should match the toggle's width.
-   */
-  constrainPanelWidth: PropTypes.bool,
-  /**
-   * An optional class to apply to the dropdown.
-   */
-  dropdownClassName: PropTypes.string,
-  /**
-   * Whether the toggle should display a chevron icon.
-   */
-  hasToggleIcon: PropTypes.bool,
-  /**
-   * A list of links to display in the menu (if the children prop is not supplied.)
-   */
-  links: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.shape(Button.propTypes),
-      PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
-    ])
-  ),
-  /**
-   * A function to call when the menu is toggled.
-   */
-  onToggleMenu: PropTypes.func,
-  /**
-   * An element to make the menu relative to.
-   */
-  positionNode: PropTypes.object,
-  /**
-   * The position of the menu.
-   */
-  position: PropTypes.oneOf(["left", "center", "right"]),
-  /**
-   * The appearance of the toggle button.
-   */
-  toggleAppearance: PropTypes.string,
-  /**
-   * An class to apply to the toggle button.
-   */
-  toggleClassName: PropTypes.string,
-  /**
-   * Whether the toggle button should be disabled.
-   */
-  toggleDisabled: PropTypes.bool,
-  /**
-   * The toggle button's label.
-   */
-  toggleLabel: PropTypes.string,
-  /**
-   * Whether the toggle lable or icon should appear first.
-   */
-  toggleLabelFirst: PropTypes.bool,
-  /**
-   * Whether the menu should be visible.
-   */
-  visible: PropTypes.bool,
 };
 
 export default ContextualMenu;

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
@@ -238,33 +237,6 @@ const ContextualMenuDropdown = <L,>({
       </span>
     </span>
   );
-};
-
-ContextualMenuDropdown.propTypes = {
-  adjustedPosition: PropTypes.string,
-  autoAdjust: PropTypes.bool,
-  closePortal: PropTypes.func,
-  constrainPanelWidth: PropTypes.bool,
-  dropdownClassName: PropTypes.string,
-  dropdownContent: PropTypes.node,
-  id: PropTypes.string,
-  isOpen: PropTypes.bool,
-  links: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.shape(Button.propTypes),
-      PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
-    ])
-  ),
-  position: PropTypes.oneOf(["left", "center", "right"]),
-  positionCoords: PropTypes.shape({
-    height: PropTypes.number.isRequired,
-    left: PropTypes.number.isRequired,
-    top: PropTypes.number.isRequired,
-    width: PropTypes.number,
-  }),
-  positionNode: PropTypes.object,
-  wrapperClass: PropTypes.string,
 };
 
 export default ContextualMenuDropdown;

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { ReactNode } from "react";
 
@@ -172,22 +171,6 @@ const Field = ({
       {stacked ? <Col size={8}>{content}</Col> : content}
     </div>
   );
-};
-
-Field.propTypes = {
-  caution: PropTypes.node,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  error: PropTypes.node,
-  forId: PropTypes.string,
-  help: PropTypes.node,
-  isSelect: PropTypes.bool,
-  label: PropTypes.node,
-  labelClassName: PropTypes.string,
-  labelFirst: PropTypes.bool,
-  required: PropTypes.bool,
-  stacked: PropTypes.bool,
-  success: PropTypes.node,
 };
 
 export default Field;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
@@ -50,12 +49,5 @@ const Form = ({
     {children}
   </form>
 );
-
-Form.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  inline: PropTypes.bool,
-  stacked: PropTypes.bool,
-};
 
 export default Form;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import type { HTMLProps } from "react";
 import React from "react";
 
@@ -60,11 +59,5 @@ const Icon = ({ className, light, name, ...props }: Props): JSX.Element => (
     {...props}
   />
 );
-
-Icon.propTypes = {
-  className: PropTypes.string,
-  light: PropTypes.bool,
-  name: PropTypes.string.isRequired,
-};
 
 export default Icon;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import type { InputHTMLAttributes, ReactNode } from "react";
 
@@ -111,22 +110,6 @@ const Input = ({
       />
     </Field>
   );
-};
-
-Input.propTypes = {
-  caution: PropTypes.node,
-  className: PropTypes.string,
-  wrapperClassName: PropTypes.string,
-  error: PropTypes.node,
-  help: PropTypes.node,
-  id: PropTypes.string,
-  label: PropTypes.node,
-  labelClassName: PropTypes.string,
-  required: PropTypes.bool,
-  stacked: PropTypes.bool,
-  success: PropTypes.node,
-  takeFocus: PropTypes.bool,
-  type: PropTypes.string,
 };
 
 export default Input;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { LabelHTMLAttributes, ReactNode } from "react";
 
@@ -42,12 +41,5 @@ const Label = ({
     {children}
   </label>
 );
-
-Label.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  forId: PropTypes.string,
-  required: PropTypes.bool,
-};
 
 export default Label;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
@@ -58,16 +57,6 @@ const Link = ({
     return <div className="p-top">{link}</div>;
   }
   return link;
-};
-
-Link.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  external: PropTypes.bool,
-  href: PropTypes.string,
-  inverted: PropTypes.bool,
-  soft: PropTypes.bool,
-  top: PropTypes.bool,
 };
 
 export default Link;

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLAttributes, ReactNode } from "react";
 
@@ -178,28 +177,6 @@ const List = ({
       {generateItems(items, ticked, inline || middot || stretch, stepped)}
     </Component>
   );
-};
-
-List.propTypes = {
-  className: PropTypes.string,
-  detailed: PropTypes.bool,
-  divided: PropTypes.bool,
-  inline: PropTypes.bool,
-  items: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.shape({
-        content: PropTypes.node,
-        title: PropTypes.node,
-        titleElement: PropTypes.string,
-      }),
-    ])
-  ).isRequired,
-  middot: PropTypes.bool,
-  stretch: PropTypes.bool,
-  split: PropTypes.bool,
-  stepped: PropTypes.bool,
-  ticked: PropTypes.bool,
 };
 
 export default List;

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
@@ -320,46 +319,6 @@ const MainTable = ({
       )}
     </>
   );
-};
-
-MainTable.propTypes = {
-  defaultSort: PropTypes.string,
-  defaultSortDirection: PropTypes.oneOf(["ascending", "descending"]),
-  /**
-   * A state that will be shown when no rows are passed to the table.
-   */
-  emptyStateMsg: PropTypes.node,
-  expanding: PropTypes.bool,
-  headers: PropTypes.arrayOf(
-    PropTypes.shape({
-      content: PropTypes.node,
-      className: PropTypes.string,
-      // The key to sort on for this header.
-      sortKey: PropTypes.string,
-    })
-  ),
-  onUpdateSort: PropTypes.func,
-  paginate: PropTypes.number,
-  responsive: PropTypes.bool,
-  rows: PropTypes.arrayOf(
-    PropTypes.shape({
-      columns: PropTypes.arrayOf(
-        PropTypes.shape({
-          children: PropTypes.node,
-          className: PropTypes.string,
-          expanding: PropTypes.bool,
-          hidden: PropTypes.bool,
-        })
-      ),
-      expanded: PropTypes.bool,
-      expandedContent: PropTypes.node,
-      // A map of sort keys to values for this row. The keys should map the
-      // sortKey values in the headers.
-      sortData: PropTypes.object,
-    })
-  ),
-  sortable: PropTypes.bool,
-  sortFunction: PropTypes.func,
 };
 
 export default MainTable;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import PropTypes from "prop-types";
 import React, { ReactElement, ReactNode, useRef, useEffect } from "react";
 
 export type Props = {
@@ -83,13 +82,6 @@ export const Modal = ({
       </section>
     </div>
   );
-};
-
-Modal.propTypes = {
-  buttonRow: PropTypes.node,
-  children: PropTypes.node.isRequired,
-  close: PropTypes.func,
-  title: PropTypes.node,
 };
 
 export default Modal;

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import PropTypes from "prop-types";
 import { useTable } from "react-table";
 import type { Column } from "react-table";
 
@@ -110,20 +109,5 @@ function ModularTable({
     </Table>
   );
 }
-
-ModularTable.propTypes = {
-  columns: PropTypes.arrayOf(
-    PropTypes.shape({
-      Header: PropTypes.node,
-      accessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      Cell: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-      className: PropTypes.string,
-      getCellIcon: PropTypes.func,
-    }).isRequired
-  ),
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  emptyMsg: PropTypes.string,
-  footer: PropTypes.node,
-};
 
 export default ModularTable;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
@@ -169,27 +168,6 @@ const Notification = ({
       )}
     </div>
   );
-};
-
-Notification.propTypes = {
-  actions: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      onClick: PropTypes.func.isRequired,
-    })
-  ),
-  borderless: PropTypes.bool,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  close: PropTypes.func, // Deprecated
-  inline: PropTypes.bool,
-  onDismiss: PropTypes.func,
-  severity: PropTypes.oneOf(Object.values(NotificationSeverity)),
-  status: PropTypes.node, // Deprecated
-  timeout: PropTypes.number,
-  timestamp: PropTypes.node,
-  title: PropTypes.node,
-  type: PropTypes.oneOf(Object.values(NotificationSeverity)), // Deprecated
 };
 
 export default Notification;

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps } from "react";
 
@@ -169,15 +168,6 @@ const Pagination = ({
       </ul>
     </nav>
   );
-};
-
-Pagination.propTypes = {
-  currentPage: PropTypes.number.isRequired,
-  itemsPerPage: PropTypes.number.isRequired,
-  paginate: PropTypes.func.isRequired,
-  totalItems: PropTypes.number.isRequired,
-  scrollToTop: PropTypes.bool,
-  truncateThreshold: PropTypes.number,
 };
 
 export default Pagination;

--- a/src/components/PaginationButton/PaginationButton.tsx
+++ b/src/components/PaginationButton/PaginationButton.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { MouseEventHandler } from "react";
 
@@ -39,12 +38,6 @@ const PaginationButton = ({
       </button>
     </li>
   );
-};
-
-PaginationButton.propTypes = {
-  direction: PropTypes.oneOf(["forward", "back"]).isRequired,
-  onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
 };
 
 export default PaginationButton;

--- a/src/components/PaginationItem/PaginationItem.tsx
+++ b/src/components/PaginationItem/PaginationItem.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { MouseEventHandler } from "react";
 
@@ -34,11 +33,5 @@ const PaginationItem = ({
     </button>
   </li>
 );
-
-PaginationItem.propTypes = {
-  number: PropTypes.number.isRequired,
-  onClick: PropTypes.func.isRequired,
-  isActive: PropTypes.bool,
-};
 
 export default PaginationItem;

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { HTMLProps } from "react";
 import type { ReactNode } from "react";
 
@@ -19,10 +18,6 @@ const RadioInput = ({ label, ...radioProps }: Props): JSX.Element => {
       {...radioProps}
     ></CheckableInput>
   );
-};
-
-RadioInput.propTypes = {
-  label: PropTypes.node.isRequired,
 };
 
 export default RadioInput;

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
@@ -19,10 +18,5 @@ const Row = ({ children, className, ...props }: Props): JSX.Element => (
     {children}
   </div>
 );
-
-Row.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
 
 export default Row;

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import React from "react";
-import PropTypes from "prop-types";
 import type { HTMLProps, FormEvent } from "react";
 
 import Icon from "../Icon";
@@ -110,17 +109,6 @@ const SearchBox = React.forwardRef<HTMLFormElement, Props>(
     );
   }
 );
-
-SearchBox.propTypes = {
-  autocomplete: PropTypes.oneOf(["on", "off"]),
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  externallyControlled: PropTypes.bool,
-  onChange: PropTypes.func,
-  onSubmit: PropTypes.func,
-  placeholder: PropTypes.string,
-  value: PropTypes.string,
-};
 
 SearchBox.displayName = "SearchBox";
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import type {
   ChangeEventHandler,
@@ -134,31 +133,6 @@ const Select = ({
       </select>
     </Field>
   );
-};
-
-Select.propTypes = {
-  caution: PropTypes.node,
-  className: PropTypes.string,
-  error: PropTypes.node,
-  help: PropTypes.node,
-  id: PropTypes.string,
-  label: PropTypes.node,
-  labelClassName: PropTypes.string,
-  onChange: PropTypes.func,
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    })
-  ).isRequired,
-  required: PropTypes.bool,
-  stacked: PropTypes.bool,
-  success: PropTypes.node,
-  /**
-   * Focus on the select box on first render.
-   */
-  takeFocus: PropTypes.bool,
-  wrapperClassName: PropTypes.string,
 };
 
 export default Select;

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import type { ChangeEventHandler, HTMLProps, ReactNode } from "react";
 
@@ -122,57 +121,6 @@ export const Slider = ({
       </div>
     </Field>
   );
-};
-
-Slider.propTypes = {
-  /**
-   * Field caution message.
-   */
-  caution: PropTypes.node,
-  /**
-   * Whether to disable the slider and input (if showInput is true).
-   */
-  disabled: PropTypes.bool,
-  /**
-   * Field error message.
-   */
-  error: PropTypes.node,
-  /**
-   * Field help message.
-   */
-  help: PropTypes.node,
-  /**
-   * Field id. Only passed to range input, not to number input.
-   */
-  id: PropTypes.string,
-  /**
-   * Whether to disable only the input, but not the slider.
-   */
-  inputDisabled: PropTypes.bool,
-  /**
-   * Field label.
-   */
-  label: PropTypes.node,
-  /**
-   * Maximum value of the slider.
-   */
-  max: PropTypes.number.isRequired,
-  /**
-   * Minimum value of the slider.
-   */
-  min: PropTypes.number.isRequired,
-  /**
-   * Change event handler.
-   */
-  onChange: PropTypes.func.isRequired,
-  /**
-   * Whether the field is required for the form to submit.
-   */
-  required: PropTypes.bool,
-  /**
-   * Whether to show a number input with the numerical value next to the slider.
-   */
-  showInput: PropTypes.bool,
 };
 
 export default Slider;

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import classNames from "classnames";
 
@@ -32,11 +31,5 @@ const Spinner = ({ className, text, isLight = false }: Props): JSX.Element => (
     )}
   </span>
 );
-
-Spinner.propTypes = {
-  className: PropTypes.string,
-  text: PropTypes.string,
-  isLight: PropTypes.bool,
-};
 
 export default Spinner;

--- a/src/components/Strip/Strip.tsx
+++ b/src/components/Strip/Strip.tsx
@@ -1,9 +1,8 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { ElementType, HTMLProps, ReactNode } from "react";
 
-import Col, { colSizes } from "../Col";
+import Col from "../Col";
 import type { ColSize } from "../Col/Col";
 import Row from "../Row";
 
@@ -100,21 +99,5 @@ const Strip = ({
     </Row>
   </Component>
 );
-
-Strip.propTypes = {
-  background: PropTypes.string,
-  bordered: PropTypes.bool,
-  children: PropTypes.node,
-  className: PropTypes.string,
-  colSize: PropTypes.oneOf(colSizes),
-  dark: PropTypes.bool,
-  deep: PropTypes.bool,
-  element: PropTypes.string,
-  includeCol: PropTypes.bool,
-  light: PropTypes.bool,
-  rowClassName: PropTypes.string,
-  shallow: PropTypes.bool,
-  type: PropTypes.string,
-};
 
 export default Strip;

--- a/src/components/SummaryButton/SummaryButton.tsx
+++ b/src/components/SummaryButton/SummaryButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { MouseEventHandler } from "react";
-import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import ActionButton from "../ActionButton";
@@ -53,13 +52,5 @@ const SummaryButton = ({
     )}
   </small>
 );
-
-SummaryButton.propTypes = {
-  className: PropTypes.string,
-  summary: PropTypes.string,
-  label: PropTypes.string,
-  onClick: PropTypes.func,
-  isLoading: PropTypes.bool,
-};
 
 export default SummaryButton;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
 export type Props = {
@@ -39,12 +38,5 @@ const Table = ({
     {children}
   </table>
 );
-
-Table.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  expanding: PropTypes.bool,
-  responsive: PropTypes.bool,
-};
 
 export default Table;

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
 export type Props = {
@@ -46,13 +45,5 @@ const TableCell = ({
     {children}
   </td>
 );
-
-TableCell.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  expanding: PropTypes.bool,
-  hidden: PropTypes.bool,
-  role: PropTypes.string,
-};
 
 export default TableCell;

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { HTMLProps, ReactNode } from "react";
 
 import { SortDirection } from "types";
@@ -20,10 +19,6 @@ const TableHeader = ({ children, sort, ...props }: Props): JSX.Element => {
       {children}
     </th>
   );
-};
-
-TableHeader.propTypes = {
-  sort: PropTypes.oneOf(["none", "ascending", "descending"]),
 };
 
 export default TableHeader;

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import type { HTMLProps, ReactNode } from "react";
 import React from "react";
 
@@ -14,9 +13,5 @@ const TableRow = ({ children, ...trProps }: Props): JSX.Element => (
     {children}
   </tr>
 );
-
-TableRow.propTypes = {
-  children: PropTypes.node,
-};
 
 export default TableRow;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React from "react";
 import type { HTMLProps, ElementType, ReactNode, ComponentType } from "react";
 
@@ -78,44 +77,6 @@ const Tabs = <P,>({
       </ul>
     </nav>
   );
-};
-
-Tabs.propTypes = {
-  /**
-   * Optional classes applied to the parent "nav" element.
-   */
-  className: PropTypes.string,
-  /**
-   * An array of tab link objects.
-   */
-  links: PropTypes.arrayOf(
-    PropTypes.shape({
-      /**
-       * Whether the tab link should have active styling.
-       */
-      active: PropTypes.bool,
-      /**
-       * Optional classes applied to the link element.
-       */
-      className: PropTypes.string,
-      /**
-       * Optional component to be used instead of the default "a" element.
-       */
-      component: PropTypes.elementType,
-      /**
-       * Label to be displayed inside the tab link.
-       */
-      label: PropTypes.node.isRequired,
-      /**
-       * Optional classes applied to the "li" element.
-       */
-      listItemClassName: PropTypes.string,
-    }).isRequired
-  ),
-  /**
-   * Optional classes applied to the "ul" element.
-   */
-  listClassName: PropTypes.string,
 };
 
 export default Tabs;

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import type { HTMLAttributes, ReactNode } from "react";
 
@@ -127,24 +126,6 @@ const Textarea = ({
       />
     </Field>
   );
-};
-
-Textarea.propTypes = {
-  caution: PropTypes.node,
-  className: PropTypes.string,
-  error: PropTypes.node,
-  grow: PropTypes.bool,
-  help: PropTypes.node,
-  id: PropTypes.string,
-  label: PropTypes.node,
-  labelClassName: PropTypes.string,
-  onKeyUp: PropTypes.func,
-  required: PropTypes.bool,
-  stacked: PropTypes.bool,
-  style: PropTypes.object,
-  success: PropTypes.node,
-  takeFocus: PropTypes.bool,
-  wrapperClassName: PropTypes.string,
 };
 
 export default Textarea;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import usePortal from "react-useportal";
@@ -278,50 +277,6 @@ const Tooltip = ({
       )}
     </>
   );
-};
-
-Tooltip.propTypes = {
-  /**
-   * Whether the tooltip should adjust to fit in the screen.
-   */
-  autoAdjust: PropTypes.bool,
-  /**
-   * Element on which to apply the tooltip.
-   */
-  children: PropTypes.node.isRequired,
-  /**
-   * An optional class to apply to the wrapping element.
-   */
-  className: PropTypes.node,
-  /**
-   * Whether the tooltip should follow the mouse.
-   */
-  followMouse: PropTypes.bool,
-  /**
-   * Message to display when the element is hovered.
-   */
-  message: PropTypes.node,
-  /**
-   * Position of the tooltip relative to the element.
-   */
-  position: PropTypes.oneOf([
-    "btm-center",
-    "btm-left",
-    "btm-right",
-    "left",
-    "right",
-    "top-center",
-    "top-left",
-    "top-right",
-  ]),
-  /**
-   * An optional class to apply to the element that wraps the children.
-   */
-  positionElementClassName: PropTypes.node,
-  /**
-   * An optional class to apply to the tooltip message element.
-   */
-  tooltipClassName: PropTypes.node,
 };
 
 export default Tooltip;

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,7 +461,7 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
-"@babel/helper-module-imports@^7.14.5":
+"@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
   integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
@@ -1158,19 +1158,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-syntax-typescript@^7.12.1", "@babel/plugin-syntax-typescript@^7.14.5", "@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
+  integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-syntax-typescript@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz#9dff111ca64154cef0f4dc52cf843d9f12ce4474"
   integrity sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
-
-"@babel/plugin-syntax-typescript@^7.14.5", "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
-  integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-arrow-functions@^7.12.1":
   version "7.12.1"
@@ -1873,7 +1873,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.11", "@babel/types@^7.14.5":
+"@babel/types@^7.12.11", "@babel/types@^7.12.6", "@babel/types@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
@@ -4662,6 +4662,16 @@ babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
+babel-plugin-typescript-to-proptypes@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-1.4.2.tgz#627a08ddc6a22d1d4d2da3bbba54d6004f7a243b"
+  integrity sha512-mcDkmEwxQ0HivEAMZ82HidppYQGiISp3bcgjtRWFFG0WzwVsJ3eQCgAoD3mSXDc9ehU8xZ7ItxCo9XRgeYQ5bQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-typescript" "^7.12.1"
+    "@babel/types" "^7.12.6"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Done

- Added a babel plugin to generate prop types: [babel-plugin-typescript-to-proptypes](https://github.com/milesj/babel-plugin-typescript-to-proptypes).
- Removed prop types from all components.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open Accordion.stories.mdx.
- Add a arg with the wrong type to the default story e.g. `onExpandedChange: false,`
- Start storybook.
- Open the accordion story and there should be a console error.

## Fixes

Fixes: #201.
