### PR TITLE
ContextualMenu optional props

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -212,4 +212,42 @@ describe("ContextualMenu ", () => {
     );
     expect(wrapper.find("Link.p-contextual-menu__link").exists()).toBe(true);
   });
+
+  it("can pass props to the contextual menu", () => {
+    const wrapper = mount(<ContextualMenu links={[]} data-test="extra-prop" />);
+    expect(wrapper.prop("data-test")).toBe("extra-prop");
+  });
+
+  it("can pass props to the toggle button", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        links={[]}
+        toggleLabel="Toggle"
+        toggleProps={{
+          appearance: "negative",
+          "data-test": "extra-prop",
+        }}
+      />
+    );
+    const button = wrapper.find("Button.p-contextual-menu__toggle");
+    expect(button.prop("appearance")).toBe("negative");
+    expect(button.prop("data-test")).toBe("extra-prop");
+  });
+
+  it("can pass props to the contextual menu dropdown", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        links={[]}
+        toggleLabel="Toggle"
+        dropdownProps={{
+          "data-test": "extra-prop",
+        }}
+      />
+    );
+    // Open the menu.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("ContextualMenuDropdown").prop("data-test")).toBe(
+      "extra-prop"
+    );
+  });
 });

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -8,7 +8,9 @@ import { useListener, usePrevious } from "../../hooks";
 import Button from "../Button";
 import type { Props as ButtonProps } from "../Button";
 import ContextualMenuDropdown from "./ContextualMenuDropdown";
+import type { Props as ContextualMenuDropdownProps } from "./ContextualMenuDropdown/ContextualMenuDropdown";
 import type { MenuLink, Position } from "./ContextualMenuDropdown";
+import { SubComponentProps } from "types";
 
 /**
  * The props for the ContextualMenu component.
@@ -42,7 +44,11 @@ export type Props<L> = {
   /**
    * An optional class to apply to the dropdown.
    */
-  dropdownClassName?: string;
+  dropdownClassName?: string | null;
+  /**
+   * Additional props to pass to the dropdown.
+   */
+  dropdownProps?: SubComponentProps<ContextualMenuDropdownProps>;
   /**
    * Whether the toggle should display a chevron icon.
    */
@@ -50,27 +56,27 @@ export type Props<L> = {
   /**
    * A list of links to display in the menu (if the children prop is not supplied.)
    */
-  links?: MenuLink<L>[];
+  links?: MenuLink<L>[] | null;
   /**
    * A function to call when the menu is toggled.
    */
-  onToggleMenu?: (isOpen: boolean) => void;
+  onToggleMenu?: (isOpen: boolean) => void | null;
   /**
    * The position of the menu.
    */
-  position?: Position;
+  position?: Position | null;
   /**
    * An element to make the menu relative to.
    */
-  positionNode?: HTMLElement;
+  positionNode?: HTMLElement | null;
   /**
    * The appearance of the toggle button.
    */
-  toggleAppearance?: ButtonProps["appearance"];
+  toggleAppearance?: ButtonProps["appearance"] | null;
   /**
    * A class to apply to the toggle button.
    */
-  toggleClassName?: string;
+  toggleClassName?: string | null;
   /**
    * Whether the toggle button should be disabled.
    */
@@ -78,11 +84,15 @@ export type Props<L> = {
   /**
    * The toggle button's label.
    */
-  toggleLabel?: string;
+  toggleLabel?: string | null;
   /**
    * Whether the toggle lable or icon should appear first.
    */
   toggleLabelFirst?: boolean;
+  /**
+   * Additional props to pass to the toggle button.
+   */
+  toggleProps?: SubComponentProps<ButtonProps>;
   /**
    * Whether the menu should be visible.
    */
@@ -150,6 +160,7 @@ const ContextualMenu = <L,>({
   closeOnOutsideClick = true,
   constrainPanelWidth,
   dropdownClassName,
+  dropdownProps,
   hasToggleIcon,
   links,
   onToggleMenu,
@@ -160,7 +171,9 @@ const ContextualMenu = <L,>({
   toggleDisabled,
   toggleLabel,
   toggleLabelFirst = true,
+  toggleProps,
   visible = false,
+  ...wrapperProps
 }: Props<L>): JSX.Element => {
   const id = useRef(nanoid());
   const wrapper = useRef();
@@ -253,6 +266,7 @@ const ContextualMenu = <L,>({
               position: "relative",
             }
       }
+      {...wrapperProps}
     >
       {hasToggle ? (
         <Button
@@ -272,6 +286,7 @@ const ContextualMenu = <L,>({
             }
           }}
           type="button"
+          {...toggleProps}
         >
           {toggleLabelFirst ? labelNode : null}
           {hasToggleIcon ? (
@@ -311,6 +326,7 @@ const ContextualMenu = <L,>({
             positionNode={getPositionNode(wrapper.current, positionNode)}
             setAdjustedPosition={setAdjustedPosition}
             wrapperClass={wrapperClass}
+            {...dropdownProps}
           />
         </Portal>
       )}

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
@@ -165,6 +165,7 @@ const ContextualMenuDropdown = <L,>({
   positionNode,
   setAdjustedPosition,
   wrapperClass,
+  ...props
 }: Props<L>): JSX.Element => {
   const dropdown = useRef();
   const [positionStyle, setPositionStyle] = useState(
@@ -201,7 +202,11 @@ const ContextualMenuDropdown = <L,>({
   }, [adjustedPosition, updatePositionStyle]);
 
   return (
-    <span className={wrapperClass} style={positionStyle as React.CSSProperties}>
+    <span
+      className={wrapperClass}
+      style={positionStyle as React.CSSProperties}
+      {...props}
+    >
       <span
         className={classNames("p-contextual-menu__dropdown", dropdownClassName)}
         id={id}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,15 @@
 export type Headings = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export type SortDirection = "none" | "ascending" | "descending";
 export type ValueOf<T> = T[keyof T];
+
+/**
+ * This type can be used when passing props to a sub component. It makes all
+ * component props optional.
+ */
+export type SubComponentProps<P> = Partial<P> & {
+  // There is currently an issue when spreading additional unknown props e.g.
+  // `data-test` which is the reason for this wildcard object. This extra type
+  // can be removed when the following issue is resolved:
+  // https://github.com/microsoft/TypeScript/issues/28960
+  [prop: string]: unknown;
+};


### PR DESCRIPTION
## Done

- Allow null to be passed to optional ContextualMenu props. 
- Pass additional props to ContextualMenu subcomponents.

## QA
N/A.

## Fixes

Fixes: #377.
Fixes: #357.
