### PR TITLE
Export types from the index

### DIFF
--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Accordion";
+export type { Props as AccordionProps } from "./Accordion";

--- a/src/components/ActionButton/index.ts
+++ b/src/components/ActionButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./ActionButton";
+export type { Props as ActionButtonProps } from "./ActionButton";

--- a/src/components/ArticlePagination/index.ts
+++ b/src/components/ArticlePagination/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./ArticlePagination";
+export type { Props as ArticlePaginationProps } from "./ArticlePagination";

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,2 +1,2 @@
 export { default, ButtonAppearance } from "./Button";
-export type { Props } from "./Button";
+export type { Props as ButtonProps } from "./Button";

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Card";
+export type { Props as CardProps } from "./Card";

--- a/src/components/CheckableInput/index.ts
+++ b/src/components/CheckableInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./CheckableInput";
+export type { Props as CheckableInputProps } from "./CheckableInput";

--- a/src/components/CheckboxInput/index.ts
+++ b/src/components/CheckboxInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./CheckboxInput";
+export type { Props as CheckboxInputProps } from "./CheckboxInput";

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Chip";
+export type { Props as ChipProps } from "./Chip";

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Code";
+export type { Props as CodeProps } from "./Code";

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React from "react";
 
 import CodeSnippetBlock from "./CodeSnippetBlock";
-import type { CodeSnippetBlockProps } from "./CodeSnippetBlock";
+import type { Props as CodeSnippetBlockProps } from "./CodeSnippetBlock";
 
 export type Props = {
   /**

--- a/src/components/CodeSnippet/CodeSnippetBlock.tsx
+++ b/src/components/CodeSnippet/CodeSnippetBlock.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import type { ReactNode } from "react";
 
 import CodeSnippetDropdown from "./CodeSnippetDropdown";
-import type { CodeSnippetDropdownProps } from "./CodeSnippetDropdown";
+import type { Props as CodeSnippetDropdownProps } from "./CodeSnippetDropdown";
 import type { ValueOf } from "../../types";
 
 export const CodeSnippetBlockAppearance = {
@@ -13,7 +13,7 @@ export const CodeSnippetBlockAppearance = {
   WINDOWS_PROMPT: "windowsPrompt",
 } as const;
 
-export type CodeSnippetBlockProps = {
+export type Props = {
   /**
    * The appearance of the code block.
    */
@@ -52,7 +52,7 @@ export default function CodeSnippetBlock({
   stacked = false,
   title,
   wrapLines = false,
-}: CodeSnippetBlockProps): JSX.Element {
+}: Props): JSX.Element {
   let className = "p-code-snippet__block";
   const isNumbered = appearance === CodeSnippetBlockAppearance.NUMBERED;
   const hasIcon =

--- a/src/components/CodeSnippet/CodeSnippetDropdown.tsx
+++ b/src/components/CodeSnippet/CodeSnippetDropdown.tsx
@@ -8,7 +8,7 @@ export type DropdownOptionProps = {
   label: string;
 } & HTMLProps<HTMLOptionElement>;
 
-export type CodeSnippetDropdownProps = {
+export type Props = {
   /**
    * Function for handling the select value changing.
    */
@@ -23,7 +23,7 @@ export default function CodeSnippetDropdown({
   options,
   onChange,
   ...props
-}: CodeSnippetDropdownProps): JSX.Element {
+}: Props): JSX.Element {
   return (
     <select className="p-code-snippet__dropdown" onChange={onChange} {...props}>
       {options.map(({ label, value, ...props }) => (

--- a/src/components/CodeSnippet/index.ts
+++ b/src/components/CodeSnippet/index.ts
@@ -1,2 +1,5 @@
 export { default } from "./CodeSnippet";
+export type { Props as CodeSnippetProps } from "./CodeSnippet";
 export { CodeSnippetBlockAppearance } from "./CodeSnippetBlock";
+export type { Props as CodeSnippetBlockProps } from "./CodeSnippetBlock";
+export type { Props as CodeSnippetDropdownProps } from "./CodeSnippetDropdown";

--- a/src/components/Col/index.ts
+++ b/src/components/Col/index.ts
@@ -1,1 +1,2 @@
 export { default, colSizes } from "./Col";
+export type { ColSize, Props as ColProps } from "./Col";

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -6,9 +6,9 @@ import usePortal from "react-useportal";
 
 import { useListener, usePrevious } from "../../hooks";
 import Button from "../Button";
-import type { Props as ButtonProps } from "../Button";
+import type { ButtonProps } from "../Button";
 import ContextualMenuDropdown from "./ContextualMenuDropdown";
-import type { Props as ContextualMenuDropdownProps } from "./ContextualMenuDropdown/ContextualMenuDropdown";
+import type { ContextualMenuDropdownProps } from "./ContextualMenuDropdown";
 import type { MenuLink, Position } from "./ContextualMenuDropdown";
 import { SubComponentProps } from "types";
 

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 import { useWindowFitment } from "../../../hooks";
 import Button from "../../Button";
-import type { Props as ButtonProps } from "../../Button";
+import type { ButtonProps } from "../../Button";
 import type { WindowFitment } from "../../../hooks";
 
 /**

--- a/src/components/ContextualMenu/ContextualMenuDropdown/index.ts
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/index.ts
@@ -1,2 +1,6 @@
 export { default } from "./ContextualMenuDropdown";
-export type { MenuLink, Position } from "./ContextualMenuDropdown";
+export type {
+  MenuLink,
+  Position,
+  Props as ContextualMenuDropdownProps,
+} from "./ContextualMenuDropdown";

--- a/src/components/ContextualMenu/index.ts
+++ b/src/components/ContextualMenu/index.ts
@@ -1,3 +1,7 @@
 export { default } from "./ContextualMenu";
-export type { Props } from "./ContextualMenu";
-export type { MenuLink, Position } from "./ContextualMenuDropdown";
+export type { Props as ContextualMenuProps } from "./ContextualMenu";
+export type {
+  ContextualMenuDropdownProps,
+  MenuLink,
+  Position,
+} from "./ContextualMenuDropdown";

--- a/src/components/Field/index.ts
+++ b/src/components/Field/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Field";
+export type { Props as FieldProps } from "./Field";

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Form";
+export type { Props as FormProps } from "./Form";

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,1 +1,2 @@
 export { default, ICONS } from "./Icon";
+export type { Props as IconProps } from "./Icon";

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Input";
+export type { Props as InputProps } from "./Input";

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Label";
+export type { Props as LabelProps } from "./Label";

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Link";
+export type { Props as LinkProps } from "./Link";

--- a/src/components/List/index.ts
+++ b/src/components/List/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./List";
+export type { Props as ListProps } from "./List";

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import Spinner from "../Spinner";
-import type { Props } from "../Spinner/Spinner";
+import type { SpinnerProps } from "../Spinner";
 import { IS_DEV } from "../../utils";
 
 /**
  * @deprecated Loader component is deprecated. Use Spinner component instead.
  */
-const Loader = (props: Props): JSX.Element => {
+const Loader = (props: SpinnerProps): JSX.Element => {
   if (IS_DEV) {
     console.warn(
       "The Loader component has been renamed to Spinner and will be removed in a future release. https://canonical-web-and-design.github.io/react-components/?path=/story/spinner--default-story"

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -4,11 +4,11 @@ import type { HTMLProps, ReactNode } from "react";
 import type { SortDirection } from "types";
 import Pagination from "../Pagination";
 import Table from "../Table";
-import type { Props as TableProps } from "../Table/Table";
+import type { TableProps } from "../Table";
 import TableRow from "../TableRow";
 import TableHeader from "../TableHeader";
 import TableCell from "../TableCell";
-import type { Props as TableCellProps } from "../TableCell/TableCell";
+import type { TableCellProps } from "../TableCell";
 
 export type MainTableHeader = {
   /**

--- a/src/components/MainTable/index.ts
+++ b/src/components/MainTable/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./MainTable";
+export type { Props as MainTableProps } from "./MainTable";

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Modal";
+export type { Props as ModalProps } from "./Modal";

--- a/src/components/ModularTable/index.ts
+++ b/src/components/ModularTable/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./ModularTable";
+export type { Props as ModularTableProps } from "./ModularTable";

--- a/src/components/Notification/index.ts
+++ b/src/components/Notification/index.ts
@@ -1,1 +1,2 @@
 export { default, NotificationSeverity } from "./Notification";
+export type { Props as NotificationProps } from "./Notification";

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Pagination";
+export type { Props as PaginationProps } from "./Pagination";

--- a/src/components/PaginationButton/index.ts
+++ b/src/components/PaginationButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./PaginationButton";
+export type { Props as PaginationButtonProps } from "./PaginationButton";

--- a/src/components/PaginationItem/index.ts
+++ b/src/components/PaginationItem/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./PaginationItem";
+export type { Props as PaginationItemProps } from "./PaginationItem";

--- a/src/components/RadioInput/index.ts
+++ b/src/components/RadioInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./RadioInput";
+export type { Props as RadioInputProps } from "./RadioInput";

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
-type Props = {
+export type Props = {
   /**
    * The content of the row.
    */

--- a/src/components/Row/index.ts
+++ b/src/components/Row/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Row";
+export type { Props as RowProps } from "./Row";

--- a/src/components/SearchAndFilter/index.ts
+++ b/src/components/SearchAndFilter/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./SearchAndFilter";
+export type { Props as SearchAndFilterProps } from "./SearchAndFilter";

--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./SearchBox";
+export type { Props as SearchBoxProps } from "./SearchBox";

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Select";
+export type { Props as SelectProps } from "./Select";

--- a/src/components/Slider/index.ts
+++ b/src/components/Slider/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Slider";
+export type { Props as SliderProps } from "./Slider";

--- a/src/components/Spinner/index.ts
+++ b/src/components/Spinner/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Spinner";
+export type { Props as SpinnerProps } from "./Spinner";

--- a/src/components/Strip/index.ts
+++ b/src/components/Strip/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Strip";
+export type { Props as StripProps } from "./Strip";

--- a/src/components/SummaryButton/index.ts
+++ b/src/components/SummaryButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./SummaryButton";
+export type { Props as SummaryButtonProps } from "./SummaryButton";

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Table";
+export type { Props as TableProps } from "./Table";

--- a/src/components/TableCell/index.ts
+++ b/src/components/TableCell/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TableCell";
+export type { Props as TableCellProps } from "./TableCell";

--- a/src/components/TableHeader/index.ts
+++ b/src/components/TableHeader/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TableHeader";
+export type { Props as TableHeaderProps } from "./TableHeader";

--- a/src/components/TableRow/index.ts
+++ b/src/components/TableRow/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TableRow";
+export type { Props as TableRowProps } from "./TableRow";

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Tabs";
+export type { Props as TabsProps } from "./Tabs";

--- a/src/components/Textarea/index.ts
+++ b/src/components/Textarea/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Textarea";
+export type { Props as TextareaProps } from "./Textarea";

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Tooltip";
+export type { Props as TooltipProps } from "./Tooltip";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 export { default as Accordion } from "./components/Accordion";
 export { default as ActionButton } from "./components/ActionButton";
 export { default as ArticlePagination } from "./components/ArticlePagination";
-export { default as Button } from "./components/Button";
+export { default as Button, ButtonAppearance } from "./components/Button";
 export { default as Card } from "./components/Card";
 export { default as CheckboxInput } from "./components/CheckboxInput";
 export { default as Chip } from "./components/Chip";
 export { default as Code } from "./components/Code";
-export { default as CodeSnippet } from "./components/CodeSnippet";
+export {
+  default as CodeSnippet,
+  CodeSnippetBlockAppearance,
+} from "./components/CodeSnippet";
 export { default as Col } from "./components/Col";
 export { default as ContextualMenu } from "./components/ContextualMenu";
 export { default as Field } from "./components/Field";
@@ -42,4 +45,64 @@ export { default as Tabs } from "./components/Tabs";
 export { default as Textarea } from "./components/Textarea";
 export { default as Tooltip } from "./components/Tooltip";
 
-export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+export type { AccordionProps } from "./components/Accordion";
+export type {
+  AccordionHeadings,
+  AccordionSectionProps,
+} from "./components/AccordionSection";
+export type { ActionButtonProps } from "./components/ActionButton";
+export type { ArticlePaginationProps } from "./components/ArticlePagination";
+export type { ButtonProps } from "./components/Button";
+export type { CardProps } from "./components/Card";
+export type { CheckableInputProps } from "./components/CheckableInput";
+export type { CheckboxInputProps } from "./components/CheckboxInput";
+export type { ChipProps } from "./components/Chip";
+export type { CodeProps } from "./components/Code";
+export type {
+  CodeSnippetProps,
+  CodeSnippetBlockProps,
+  CodeSnippetDropdownProps,
+} from "./components/CodeSnippet";
+export type { ColProps, ColSize } from "./components/Col";
+export type {
+  ContextualMenuProps,
+  ContextualMenuDropdownProps,
+  MenuLink,
+  Position,
+} from "./components/ContextualMenu";
+export type { FieldProps } from "./components/Field";
+export type { FormProps } from "./components/Form";
+export type { IconProps } from "./components/Icon";
+export type { InputProps } from "./components/Input";
+export type { LabelProps } from "./components/Label";
+export type { LinkProps } from "./components/Link";
+export type { ListProps } from "./components/List";
+export type { MainTableProps } from "./components/MainTable";
+export type { ModularTableProps } from "./components/ModularTable";
+export type { ModalProps } from "./components/Modal";
+export type { NotificationProps } from "./components/Notification";
+export type { PaginationProps } from "./components/Pagination";
+export type { RadioInputProps } from "./components/RadioInput";
+export type { RowProps } from "./components/Row";
+export type { SearchAndFilterProps } from "./components/SearchAndFilter";
+export type { SearchBoxProps } from "./components/SearchBox";
+export type { SelectProps } from "./components/Select";
+export type { SliderProps } from "./components/Slider";
+export type { SpinnerProps } from "./components/Spinner";
+export type { StripProps } from "./components/Strip";
+export type { SummaryButtonProps } from "./components/SummaryButton";
+export type { TableProps } from "./components/Table";
+export type { TableCellProps } from "./components/TableCell";
+export type { TableHeaderProps } from "./components/TableHeader";
+export type { TableRowProps } from "./components/TableRow";
+export type { TabsProps } from "./components/Tabs";
+export type { TextareaProps } from "./components/Textarea";
+export type { TooltipProps } from "./components/Tooltip";
+
+export type {
+  Headings,
+  SortDirection,
+  SubComponentProps,
+  TSFixMe,
+  ValueOf,
+} from "./types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,5 @@
 export type Headings = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 export type SortDirection = "none" | "ascending" | "descending";
-export type ValueOf<T> = T[keyof T];
-
 /**
  * This type can be used when passing props to a sub component. It makes all
  * component props optional.
@@ -13,3 +11,5 @@ export type SubComponentProps<P> = Partial<P> & {
   // https://github.com/microsoft/TypeScript/issues/28960
   [prop: string]: unknown;
 };
+export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
## Done

- Export types form the index so they can be imported nicely

## QA

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- N/A, unless you want to build and install the tarball and check that you can import types in a project like:
  ``` typescript
  import type { ButtonProps } from "@canonical/react-components";
  ```

## Fixes

Fixes #553 
