### PR TITLE
Add generic type for spreading props

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,7 +7,7 @@ import type {
   AccordionSectionProps,
 } from "components/AccordionSection";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 export type Section = AccordionSectionProps & {
   /**
@@ -17,35 +17,38 @@ export type Section = AccordionSectionProps & {
   key?: string | number;
 };
 
-export type Props = {
-  /**
-   * Optional classes applied to the parent element.
-   */
-  className?: ClassName;
-  /**
-   * An optional value to set the expanded section. The value must match a
-   * section key. This value will only set the expanded section on first render
-   * if externallyControlled is not set to `true`.
-   */
-  expanded?: string;
-  /**
-   * Whether the expanded section will be controlled via external state.
-   */
-  externallyControlled?: boolean;
-  /**
-   * Optional function that is called when the expanded section is changed.
-   * The function is provided the section title or null.
-   */
-  onExpandedChange?: (id, title: string) => void;
-  /**
-   * An array of sections and content.
-   */
-  sections: Section[];
-  /**
-   * Optional string describing heading element that should be used for the section titles.
-   */
-  titleElement?: AccordionHeadings;
-} & HTMLProps<HTMLElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Optional classes applied to the parent element.
+     */
+    className?: ClassName;
+    /**
+     * An optional value to set the expanded section. The value must match a
+     * section key. This value will only set the expanded section on first render
+     * if externallyControlled is not set to `true`.
+     */
+    expanded?: string;
+    /**
+     * Whether the expanded section will be controlled via external state.
+     */
+    externallyControlled?: boolean;
+    /**
+     * Optional function that is called when the expanded section is changed.
+     * The function is provided the section title or null.
+     */
+    onExpandedChange?: (id, title: string) => void;
+    /**
+     * An array of sections and content.
+     */
+    sections: Section[];
+    /**
+     * Optional string describing heading element that should be used for the section titles.
+     */
+    titleElement?: AccordionHeadings;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 const generateSections = (
   sections: Section[],

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -2,44 +2,48 @@ import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
+import type { ButtonProps } from "../Button";
+import { ButtonAppearance } from "../Button";
 import Icon from "../Icon";
-import { ButtonAppearance } from "../Button/Button";
 
-import type { ClassName, ValueOf } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 export const LOADER_MIN_DURATION = 400; // minimium duration (ms) loader displays
 export const SUCCESS_DURATION = 2000; // duration (ms) success tick is displayed
 
-export type Props = {
-  /**
-   * The appearance of the button.
-   */
-  appearance?: ValueOf<typeof ButtonAppearance>;
-  /**
-   * The content of the button.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the button element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the button should be disabled.
-   */
-  disabled?: boolean;
-  /**
-   * Whether the button should display inline.
-   */
-  inline?: boolean;
-  /**
-   * Whether the button should be in the loading state.
-   */
-  loading?: boolean;
-  /**
-   * Whether the button should be in the success state.
-   */
-  success?: boolean;
-} & ButtonHTMLAttributes<HTMLButtonElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The appearance of the button.
+     */
+    appearance?: ButtonProps["appearance"];
+    /**
+     * The content of the button.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the button element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the button should be disabled.
+     */
+    disabled?: boolean;
+    /**
+     * Whether the button should display inline.
+     */
+    inline?: boolean;
+    /**
+     * Whether the button should be in the loading state.
+     */
+    loading?: boolean;
+    /**
+     * Whether the button should be in the success state.
+     */
+    success?: boolean;
+  },
+  ButtonHTMLAttributes<HTMLButtonElement>
+>;
 
 const ActionButton = ({
   appearance = ButtonAppearance.NEUTRAL,

--- a/src/components/ArticlePagination/ArticlePagination.tsx
+++ b/src/components/ArticlePagination/ArticlePagination.tsx
@@ -2,30 +2,33 @@ import classNames from "classnames";
 import React from "react";
 import type { HTMLProps } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * Optional classes to add to the wrapping element.
-   */
-  className?: ClassName;
-  /**
-   * The URL for the next link.
-   */
-  nextURL?: string;
-  /**
-   * The label for the next link.
-   */
-  nextLabel?: string;
-  /**
-   * The URL for the previous link.
-   */
-  previousURL?: string;
-  /**
-   * The label for the previous link.
-   */
-  previousLabel?: string;
-} & HTMLProps<HTMLElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Optional classes to add to the wrapping element.
+     */
+    className?: ClassName;
+    /**
+     * The URL for the next link.
+     */
+    nextURL?: string;
+    /**
+     * The label for the next link.
+     */
+    nextLabel?: string;
+    /**
+     * The URL for the previous link.
+     */
+    previousURL?: string;
+    /**
+     * The label for the previous link.
+     */
+    previousLabel?: string;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 const ArticlePagination = ({
   className,

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,34 +2,37 @@ import classNames from "classnames";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the card.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping div element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the card should have highlighted styling.
-   */
-  highlighted?: boolean;
-  /**
-   * Whether the card should have overlay styling.
-   */
-  overlay?: boolean;
-  /**
-   * The path to a thumbnail image.
-   */
-  thumbnail?: string;
-  /**
-   * The title of the card.
-   */
-  title?: ReactNode;
-} & Omit<HTMLProps<HTMLDivElement>, "title">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the card.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping div element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the card should have highlighted styling.
+     */
+    highlighted?: boolean;
+    /**
+     * Whether the card should have overlay styling.
+     */
+    overlay?: boolean;
+    /**
+     * The path to a thumbnail image.
+     */
+    thumbnail?: string;
+    /**
+     * The title of the card.
+     */
+    title?: ReactNode;
+  },
+  HTMLProps<HTMLDivElement>
+>;
 
 const Card = ({
   children,

--- a/src/components/CheckableInput/CheckableInput.tsx
+++ b/src/components/CheckableInput/CheckableInput.tsx
@@ -3,20 +3,27 @@ import { nanoid } from "nanoid";
 import React, { useEffect, useRef, HTMLProps } from "react";
 import type { ReactNode } from "react";
 
-export type Props = {
-  /**
-   * The type of the input element.
-   */
-  inputType: "radio" | "checkbox";
-  /**
-   * The label for the input element.
-   */
-  label: ReactNode;
-  /**
-   * Whether the input element should display in indeterminate state.
-   */
-  indeterminate?: boolean;
-} & Omit<HTMLProps<HTMLInputElement>, "type">;
+import type { PropsWithSpread } from "types";
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The type of the input element.
+     */
+    inputType: "radio" | "checkbox";
+    /**
+     * The label for the input element.
+     */
+    label: ReactNode;
+    /**
+     * Whether the input element should display in indeterminate state.
+     */
+    indeterminate?: boolean;
+  },
+  // We explicitly omit "type" otherwise it's possible to overwrite "inputType".
+  // Might want to consider just using "type" instead.
+  Omit<HTMLProps<HTMLInputElement>, "type">
+>;
 
 const CheckableInput = ({
   inputType,

--- a/src/components/Col/Col.tsx
+++ b/src/components/Col/Col.tsx
@@ -2,54 +2,57 @@ import classNames from "classnames";
 import React from "react";
 import type { ElementType, HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 export type ColSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export const colSizes: ColSize[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-export type Props = {
-  /**
-   * The content of the column.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping element.
-   */
-  className?: ClassName;
-  /**
-   * Optional element type to give the wrapper if not "div".
-   */
-  element?: ElementType;
-  /**
-   * The number of columns to skip before starting on large screens.
-   */
-  emptyLarge?: ColSize;
-  /**
-   * The number of columns to skip before starting on medium screens.
-   */
-  emptyMedium?: ColSize;
-  /**
-   * The number of columns to skip before starting on small screens.
-   */
-  emptySmall?: ColSize;
-  /**
-   * Override for the number of columns the content occupies on large screens.
-   */
-  large?: ColSize;
-  /**
-   * Override for the number of columns the content occupies on medium screens.
-   */
-  medium?: ColSize;
-  /**
-   * The number of columns the content occupies.
-   */
-  size: ColSize;
-  /**
-   * Override for the number of columns the content occupies on small screens.
-   */
-  small?: ColSize;
-} & HTMLProps<HTMLElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the column.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping element.
+     */
+    className?: ClassName;
+    /**
+     * Optional element type to give the wrapper if not "div".
+     */
+    element?: ElementType;
+    /**
+     * The number of columns to skip before starting on large screens.
+     */
+    emptyLarge?: ColSize;
+    /**
+     * The number of columns to skip before starting on medium screens.
+     */
+    emptyMedium?: ColSize;
+    /**
+     * The number of columns to skip before starting on small screens.
+     */
+    emptySmall?: ColSize;
+    /**
+     * Override for the number of columns the content occupies on large screens.
+     */
+    large?: ColSize;
+    /**
+     * Override for the number of columns the content occupies on medium screens.
+     */
+    medium?: ColSize;
+    /**
+     * The number of columns the content occupies.
+     */
+    size: ColSize;
+    /**
+     * Override for the number of columns the content occupies on small screens.
+     */
+    small?: ColSize;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 const Col = ({
   children,

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -10,94 +10,97 @@ import type { ButtonProps } from "../Button";
 import ContextualMenuDropdown from "./ContextualMenuDropdown";
 import type { ContextualMenuDropdownProps } from "./ContextualMenuDropdown";
 import type { MenuLink, Position } from "./ContextualMenuDropdown";
-import { ClassName, SubComponentProps } from "types";
+import { ClassName, PropsWithSpread, SubComponentProps } from "types";
 
 /**
  * The props for the ContextualMenu component.
  * @template L - The type of the link props.
  */
-export type Props<L> = {
-  /**
-   * Whether the menu should adjust to fit in the screen.
-   */
-  autoAdjust?: boolean;
-  /**
-   * The menu content (if the links prop is not supplied).
-   */
-  children?: ReactNode;
-  /**
-   * An optional class to apply to the wrapping element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the menu should close when the escape key is pressed.
-   */
-  closeOnEsc?: boolean;
-  /**
-   * Whether the menu should close when clicking outside the menu.
-   */
-  closeOnOutsideClick?: boolean;
-  /**
-   * Whether the menu's width should match the toggle's width.
-   */
-  constrainPanelWidth?: boolean;
-  /**
-   * An optional class to apply to the dropdown.
-   */
-  dropdownClassName?: string | null;
-  /**
-   * Additional props to pass to the dropdown.
-   */
-  dropdownProps?: SubComponentProps<ContextualMenuDropdownProps>;
-  /**
-   * Whether the toggle should display a chevron icon.
-   */
-  hasToggleIcon?: boolean;
-  /**
-   * A list of links to display in the menu (if the children prop is not supplied.)
-   */
-  links?: MenuLink<L>[] | null;
-  /**
-   * A function to call when the menu is toggled.
-   */
-  onToggleMenu?: (isOpen: boolean) => void | null;
-  /**
-   * The position of the menu.
-   */
-  position?: Position | null;
-  /**
-   * An element to make the menu relative to.
-   */
-  positionNode?: HTMLElement | null;
-  /**
-   * The appearance of the toggle button.
-   */
-  toggleAppearance?: ButtonProps["appearance"] | null;
-  /**
-   * A class to apply to the toggle button.
-   */
-  toggleClassName?: string | null;
-  /**
-   * Whether the toggle button should be disabled.
-   */
-  toggleDisabled?: boolean;
-  /**
-   * The toggle button's label.
-   */
-  toggleLabel?: string | null;
-  /**
-   * Whether the toggle lable or icon should appear first.
-   */
-  toggleLabelFirst?: boolean;
-  /**
-   * Additional props to pass to the toggle button.
-   */
-  toggleProps?: SubComponentProps<ButtonProps>;
-  /**
-   * Whether the menu should be visible.
-   */
-  visible?: boolean;
-} & HTMLProps<HTMLSpanElement>;
+export type Props<L> = PropsWithSpread<
+  {
+    /**
+     * Whether the menu should adjust to fit in the screen.
+     */
+    autoAdjust?: boolean;
+    /**
+     * The menu content (if the links prop is not supplied).
+     */
+    children?: ReactNode;
+    /**
+     * An optional class to apply to the wrapping element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the menu should close when the escape key is pressed.
+     */
+    closeOnEsc?: boolean;
+    /**
+     * Whether the menu should close when clicking outside the menu.
+     */
+    closeOnOutsideClick?: boolean;
+    /**
+     * Whether the menu's width should match the toggle's width.
+     */
+    constrainPanelWidth?: boolean;
+    /**
+     * An optional class to apply to the dropdown.
+     */
+    dropdownClassName?: string | null;
+    /**
+     * Additional props to pass to the dropdown.
+     */
+    dropdownProps?: SubComponentProps<ContextualMenuDropdownProps>;
+    /**
+     * Whether the toggle should display a chevron icon.
+     */
+    hasToggleIcon?: boolean;
+    /**
+     * A list of links to display in the menu (if the children prop is not supplied.)
+     */
+    links?: MenuLink<L>[] | null;
+    /**
+     * A function to call when the menu is toggled.
+     */
+    onToggleMenu?: (isOpen: boolean) => void | null;
+    /**
+     * The position of the menu.
+     */
+    position?: Position | null;
+    /**
+     * An element to make the menu relative to.
+     */
+    positionNode?: HTMLElement | null;
+    /**
+     * The appearance of the toggle button.
+     */
+    toggleAppearance?: ButtonProps["appearance"] | null;
+    /**
+     * A class to apply to the toggle button.
+     */
+    toggleClassName?: string | null;
+    /**
+     * Whether the toggle button should be disabled.
+     */
+    toggleDisabled?: boolean;
+    /**
+     * The toggle button's label.
+     */
+    toggleLabel?: string | null;
+    /**
+     * Whether the toggle lable or icon should appear first.
+     */
+    toggleLabelFirst?: boolean;
+    /**
+     * Additional props to pass to the toggle button.
+     */
+    toggleProps?: SubComponentProps<ButtonProps>;
+    /**
+     * Whether the menu should be visible.
+     */
+    visible?: boolean;
+  },
+  HTMLProps<HTMLSpanElement>
+>;
 
 /**
  * Get the node to use for positioning the menu.

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -2,20 +2,23 @@ import classNames from "classnames";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the form.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the form element.
-   */
-  className?: ClassName;
-  inline?: boolean;
-  stacked?: boolean;
-} & HTMLProps<HTMLFormElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the form.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the form element.
+     */
+    className?: ClassName;
+    inline?: boolean;
+    stacked?: boolean;
+  },
+  HTMLProps<HTMLFormElement>
+>;
 
 const Form = ({
   children,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import type { HTMLProps } from "react";
 import React from "react";
 
-import type { ClassName, ValueOf } from "types";
+import type { ClassName, PropsWithSpread, ValueOf } from "types";
 
 export const ICONS = {
   anchor: "anchor",
@@ -30,20 +30,23 @@ export const ICONS = {
   warning: "warning",
 } as const;
 
-export type Props = {
-  /**
-   * Optional classes to add to the icon element.
-   */
-  className?: ClassName;
-  /**
-   * Whether to show the light variant of the icon.
-   */
-  light?: boolean;
-  /**
-   * The name of the icon.
-   */
-  name: ValueOf<typeof ICONS> | string;
-} & HTMLProps<HTMLElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Optional classes to add to the icon element.
+     */
+    className?: ClassName;
+    /**
+     * Whether to show the light variant of the icon.
+     */
+    light?: boolean;
+    /**
+     * The name of the icon.
+     */
+    name: ValueOf<typeof ICONS> | string;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 /**
  * Icon

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,61 +4,64 @@ import type { InputHTMLAttributes, ReactNode } from "react";
 
 import Field from "../Field";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 /**
  * The props for the Input component.
  */
-export type Props = {
-  /**
-   * The content for caution validation.
-   */
-  caution?: ReactNode;
-  /**
-   * Optional class(es) to pass to the input element.
-   */
-  className?: ClassName;
-  /**
-   * The content for error validation.
-   */
-  error?: ReactNode;
-  /**
-   * Help text to show below the field.
-   */
-  help?: ReactNode;
-  /**
-   * The id of the input.
-   */
-  id?: string;
-  /**
-   * The label for the field.
-   */
-  label?: ReactNode;
-  /**
-   * Optional class(es) to pass to the label component.
-   */
-  labelClassName?: string;
-  /**
-   * Whether the field is required.
-   */
-  required?: boolean;
-  /**
-   * Whether the form field should have a stacked appearance.
-   */
-  stacked?: boolean;
-  /**
-   * The content for success validation.
-   */
-  success?: ReactNode;
-  /**
-   * Whether to focus on the input on initial render.
-   */
-  takeFocus?: boolean;
-  /**
-   * Optional class(es) to pass to the wrapping Field component
-   */
-  wrapperClassName?: string;
-} & InputHTMLAttributes<HTMLInputElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content for caution validation.
+     */
+    caution?: ReactNode;
+    /**
+     * Optional class(es) to pass to the input element.
+     */
+    className?: ClassName;
+    /**
+     * The content for error validation.
+     */
+    error?: ReactNode;
+    /**
+     * Help text to show below the field.
+     */
+    help?: ReactNode;
+    /**
+     * The id of the input.
+     */
+    id?: string;
+    /**
+     * The label for the field.
+     */
+    label?: ReactNode;
+    /**
+     * Optional class(es) to pass to the label component.
+     */
+    labelClassName?: string;
+    /**
+     * Whether the field is required.
+     */
+    required?: boolean;
+    /**
+     * Whether the form field should have a stacked appearance.
+     */
+    stacked?: boolean;
+    /**
+     * The content for success validation.
+     */
+    success?: ReactNode;
+    /**
+     * Whether to focus on the input on initial render.
+     */
+    takeFocus?: boolean;
+    /**
+     * Optional class(es) to pass to the wrapping Field component
+     */
+    wrapperClassName?: string;
+  },
+  InputHTMLAttributes<HTMLInputElement>
+>;
 
 const Input = ({
   caution,

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,29 +2,32 @@ import classNames from "classnames";
 import React from "react";
 import type { LabelHTMLAttributes, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 /**
  * The props for the Label component.
  */
-export type Props = {
-  /**
-   * The label content.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to give to the label element.
-   */
-  className?: ClassName;
-  /**
-   * The id of the input this label is connected to.
-   */
-  forId?: string;
-  /**
-   * Whether to apply required styling to the label.
-   */
-  required?: boolean;
-} & LabelHTMLAttributes<HTMLLabelElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The label content.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to give to the label element.
+     */
+    className?: ClassName;
+    /**
+     * The id of the input this label is connected to.
+     */
+    forId?: string;
+    /**
+     * Whether to apply required styling to the label.
+     */
+    required?: boolean;
+  },
+  LabelHTMLAttributes<HTMLLabelElement>
+>;
 
 const Label = ({
   children,

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,34 +2,37 @@ import classNames from "classnames";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the link.
-   */
-  children: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping anchor element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the link should have external styling.
-   */
-  external?: boolean;
-  /**
-   * Whether the link should have inverted styling.
-   */
-  inverted?: boolean;
-  /**
-   * Whether the link should have soft styling.
-   */
-  soft?: boolean;
-  /**
-   * Whether the link should have "back to top" styling.
-   */
-  top?: boolean;
-} & HTMLProps<HTMLAnchorElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the link.
+     */
+    children: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping anchor element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the link should have external styling.
+     */
+    external?: boolean;
+    /**
+     * Whether the link should have inverted styling.
+     */
+    inverted?: boolean;
+    /**
+     * Whether the link should have soft styling.
+     */
+    soft?: boolean;
+    /**
+     * Whether the link should have "back to top" styling.
+     */
+    top?: boolean;
+  },
+  HTMLProps<HTMLAnchorElement>
+>;
 
 const Link = ({
   children,

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
-import type { ClassName, SortDirection } from "types";
+import type { ClassName, PropsWithSpread, SortDirection } from "types";
 import Pagination from "../Pagination";
 import Table from "../Table";
 import type { TableProps } from "../Table";
@@ -10,99 +10,113 @@ import TableHeader from "../TableHeader";
 import TableCell from "../TableCell";
 import type { TableCellProps } from "../TableCell";
 
-export type MainTableHeader = {
-  /**
-   * The content of the table header.
-   */
-  content?: ReactNode;
-  /**
-   * Optional classes to apply to the table header.
-   */
-  className?: ClassName;
-  /**
-   * A key to sort the rows by. It should match a key given to the row `sortData`.
-   */
-  sortKey?: string | null;
-} & Omit<HTMLProps<HTMLTableHeaderCellElement>, "content">;
+export type MainTableHeader = PropsWithSpread<
+  {
+    /**
+     * The content of the table header.
+     */
+    content?: ReactNode;
+    /**
+     * Optional classes to apply to the table header.
+     */
+    className?: ClassName;
+    /**
+     * A key to sort the rows by. It should match a key given to the row `sortData`.
+     */
+    sortKey?: string | null;
+  },
+  HTMLProps<HTMLTableHeaderCellElement>
+>;
 
-export type MainTableCell = {
-  /**
-   * The content of the table cell.
-   */
-  content?: ReactNode;
-} & Omit<TableCellProps, "children" | "content">;
+export type MainTableCell = PropsWithSpread<
+  {
+    /**
+     * The content of the table cell.
+     */
+    content?: ReactNode;
+  },
+  // We explicitly omit "children" otherwise it's possible to overwrite "content".
+  // Might want to consider just using "children" instead.
+  Omit<TableCellProps, "children">
+>;
 
-export type MainTableRow = {
-  /**
-   * Optional class(es) to apply to the row.
-   */
-  className?: ClassName;
-  /**
-   * The columns in this row.
-   */
-  columns?: MainTableCell[];
-  /**
-   * Whether this row should display as expanded.
-   */
-  expanded?: boolean;
-  /**
-   * The content to display when this column is expanded.
-   */
-  expandedContent?: ReactNode;
-  /**
-   * An optional key to identify this table row.
-   */
-  key?: number | string | null;
-  /**
-   * An object of data for use when sorting the rows. The keys of this object
-   * should match the header sort keys.
-   */
-  sortData?: Record<string, unknown>;
-} & Omit<HTMLProps<HTMLTableRowElement>, "className">;
+export type MainTableRow = PropsWithSpread<
+  {
+    /**
+     * Optional class(es) to apply to the row.
+     */
+    className?: ClassName;
+    /**
+     * The columns in this row.
+     */
+    columns?: MainTableCell[];
+    /**
+     * Whether this row should display as expanded.
+     */
+    expanded?: boolean;
+    /**
+     * The content to display when this column is expanded.
+     */
+    expandedContent?: ReactNode;
+    /**
+     * An optional key to identify this table row.
+     */
+    key?: number | string | null;
+    /**
+     * An object of data for use when sorting the rows. The keys of this object
+     * should match the header sort keys.
+     */
+    sortData?: Record<string, unknown>;
+  },
+  HTMLProps<HTMLTableRowElement>
+>;
 
-export type Props = {
-  /**
-   * The default key to sort the rows by.
-   */
-  defaultSort?: MainTableHeader["sortKey"];
-  /**
-   * The default direction the row data should be sorted by.
-   */
-  defaultSortDirection?: SortDirection;
-  /**
-   * A message to display when there are no table rows.
-   */
-  emptyStateMsg?: ReactNode;
-  /**
-   * The header columns for this table.
-   */
-  headers?: MainTableHeader[];
-  /**
-   * A function that is called when the sort key is changed.
-   */
-  onUpdateSort?: (sortKey: MainTableHeader["sortKey"]) => void;
-  /**
-   * A number of rows to paginate by.
-   */
-  paginate?: number | null;
-  /**
-   * The rows to display in the table.
-   */
-  rows?: MainTableRow[];
-  /**
-   * Whether this table should be sortable.
-   */
-  sortable?: boolean;
-  /**
-   * A function to be used when sorting.
-   */
-  sortFunction?: (
-    a: MainTableRow,
-    b: MainTableRow,
-    currentSortDirection: SortDirection,
-    currentSortKey: MainTableHeader["sortKey"]
-  ) => -1 | 0 | 1;
-} & Omit<TableProps, "children" | "headers" | "rows">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The default key to sort the rows by.
+     */
+    defaultSort?: MainTableHeader["sortKey"];
+    /**
+     * The default direction the row data should be sorted by.
+     */
+    defaultSortDirection?: SortDirection;
+    /**
+     * A message to display when there are no table rows.
+     */
+    emptyStateMsg?: ReactNode;
+    /**
+     * The header columns for this table.
+     */
+    headers?: MainTableHeader[];
+    /**
+     * A function that is called when the sort key is changed.
+     */
+    onUpdateSort?: (sortKey: MainTableHeader["sortKey"]) => void;
+    /**
+     * A number of rows to paginate by.
+     */
+    paginate?: number | null;
+    /**
+     * The rows to display in the table.
+     */
+    rows?: MainTableRow[];
+    /**
+     * Whether this table should be sortable.
+     */
+    sortable?: boolean;
+    /**
+     * A function to be used when sorting.
+     */
+    sortFunction?: (
+      a: MainTableRow,
+      b: MainTableRow,
+      currentSortDirection: SortDirection,
+      currentSortKey: MainTableHeader["sortKey"]
+    ) => -1 | 0 | 1;
+  },
+  TableProps
+>;
 
 const updateSort = (
   setSortKey: (sortKey: MainTableHeader["sortKey"]) => void,

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -5,7 +5,7 @@ import type { HTMLProps, ReactNode } from "react";
 import Button, { ButtonAppearance } from "../Button";
 import { IS_DEV } from "../../utils";
 
-import type { ClassName, ValueOf } from "types";
+import type { ClassName, PropsWithSpread, ValueOf } from "types";
 
 export const NotificationSeverity = {
   CAUTION: "caution",
@@ -22,60 +22,63 @@ type NotificationAction = {
 /**
  * The props for the Notification component.
  */
-export type Props = {
-  /**
-   * A list of up to two actions that the notification can perform.
-   */
-  actions?: NotificationAction[];
-  /**
-   * Whether the notification should not have a border.
-   */
-  borderless?: boolean;
-  /**
-   * The notification message content.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to apply to the parent notification element.
-   */
-  className?: ClassName;
-  /**
-   * **Deprecated**. Use `onDismiss` instead.
-   */
-  close?: never;
-  /**
-   * Whether the title should display inline with the message.
-   */
-  inline?: boolean;
-  /**
-   * The function to run when dismissing/closing the notification.
-   */
-  onDismiss?: () => void;
-  /**
-   * The severity of the notification.
-   */
-  severity?: ValueOf<typeof NotificationSeverity>;
-  /**
-   * **Deprecated**. Use `title` instead.
-   */
-  status?: never;
-  /**
-   * The amount of time (in ms) until the notification is automatically dismissed.
-   */
-  timeout?: number;
-  /**
-   * A relevant timestamp for the notification, e.g. when it was created.
-   */
-  timestamp?: ReactNode;
-  /**
-   * The title of the notification.
-   */
-  title?: ReactNode;
-  /**
-   * **Deprecated**. Use `severity` instead.
-   */
-  type?: never;
-} & Omit<HTMLProps<HTMLDivElement>, "title">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * A list of up to two actions that the notification can perform.
+     */
+    actions?: NotificationAction[];
+    /**
+     * Whether the notification should not have a border.
+     */
+    borderless?: boolean;
+    /**
+     * The notification message content.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to apply to the parent notification element.
+     */
+    className?: ClassName;
+    /**
+     * **Deprecated**. Use `onDismiss` instead.
+     */
+    close?: never;
+    /**
+     * Whether the title should display inline with the message.
+     */
+    inline?: boolean;
+    /**
+     * The function to run when dismissing/closing the notification.
+     */
+    onDismiss?: () => void;
+    /**
+     * The severity of the notification.
+     */
+    severity?: ValueOf<typeof NotificationSeverity>;
+    /**
+     * **Deprecated**. Use `title` instead.
+     */
+    status?: never;
+    /**
+     * The amount of time (in ms) until the notification is automatically dismissed.
+     */
+    timeout?: number;
+    /**
+     * A relevant timestamp for the notification, e.g. when it was created.
+     */
+    timestamp?: ReactNode;
+    /**
+     * The title of the notification.
+     */
+    title?: ReactNode;
+    /**
+     * **Deprecated**. Use `severity` instead.
+     */
+    type?: never;
+  },
+  HTMLProps<HTMLDivElement>
+>;
 
 const Notification = ({
   actions,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -4,6 +4,8 @@ import type { HTMLProps } from "react";
 import PaginationButton from "../PaginationButton";
 import PaginationItem from "../PaginationItem";
 
+import type { PropsWithSpread } from "types";
+
 const scrollTop = () => window.scrollTo(0, 0);
 
 const generatePaginationItems = (
@@ -90,32 +92,35 @@ const PaginationItemSeparator = (): JSX.Element => (
   </li>
 );
 
-export type Props = {
-  /**
-   * The current page being viewed.
-   */
-  currentPage: number;
-  /**
-   * The number of items to show per page.
-   */
-  itemsPerPage: number;
-  /**
-   * Function to handle paginating the items.
-   */
-  paginate: (page: number) => void;
-  /**
-   * The total number of items.
-   */
-  totalItems: number;
-  /**
-   * Whether to scroll to the top of the list on page change.
-   */
-  scrollToTop?: boolean;
-  /**
-   * The number of pages at which to truncate the pagination items.
-   */
-  truncateThreshold?: number;
-} & HTMLProps<HTMLElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The current page being viewed.
+     */
+    currentPage: number;
+    /**
+     * The number of items to show per page.
+     */
+    itemsPerPage: number;
+    /**
+     * Function to handle paginating the items.
+     */
+    paginate: (page: number) => void;
+    /**
+     * The total number of items.
+     */
+    totalItems: number;
+    /**
+     * Whether to scroll to the top of the list on page change.
+     */
+    scrollToTop?: boolean;
+    /**
+     * The number of pages at which to truncate the pagination items.
+     */
+    truncateThreshold?: number;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 const Pagination = ({
   itemsPerPage,

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,18 +1,21 @@
 import classNames from "classnames";
 import React from "react";
 import type { HTMLProps, ReactNode } from "react";
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the row.
-   */
-  children: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping div element.
-   */
-  className?: ClassName;
-} & HTMLProps<HTMLDivElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the row.
+     */
+    children: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping div element.
+     */
+    className?: ClassName;
+  },
+  HTMLProps<HTMLDivElement>
+>;
 
 const Row = ({ children, className, ...props }: Props): JSX.Element => (
   <div className={classNames(className, "row")} {...props}>

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -4,42 +4,45 @@ import type { HTMLProps, FormEvent } from "react";
 
 import Icon from "../Icon";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * Whether autocomplete should be enabled for the search input.
-   */
-  autocomplete?: "on" | "off";
-  /**
-   * Optional classes to pass to the form element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the input and buttons should be disabled.
-   */
-  disabled?: boolean;
-  /**
-   * Whether the input value will be controlled via external state.
-   */
-  externallyControlled?: boolean;
-  /**
-   * A function that will be called when the input value changes.
-   */
-  onChange?: (inputValue: string) => void;
-  /**
-   * A function that will be called when the form is submitted.
-   */
-  onSubmit?: (evt: FormEvent) => void;
-  /**
-   * A search input placeholder message.
-   */
-  placeholder?: string;
-  /**
-   * The value of the search input when the state is externally controlled.
-   */
-  value?: string;
-} & Omit<HTMLProps<HTMLFormElement>, "onChange" | "onSubmit" | "value">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Whether autocomplete should be enabled for the search input.
+     */
+    autocomplete?: "on" | "off";
+    /**
+     * Optional classes to pass to the form element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the input and buttons should be disabled.
+     */
+    disabled?: boolean;
+    /**
+     * Whether the input value will be controlled via external state.
+     */
+    externallyControlled?: boolean;
+    /**
+     * A function that will be called when the input value changes.
+     */
+    onChange?: (inputValue: string) => void;
+    /**
+     * A function that will be called when the form is submitted.
+     */
+    onSubmit?: (evt: FormEvent) => void;
+    /**
+     * A search input placeholder message.
+     */
+    placeholder?: string;
+    /**
+     * The value of the search input when the state is externally controlled.
+     */
+    value?: string;
+  },
+  HTMLProps<HTMLFormElement>
+>;
 
 const SearchBox = React.forwardRef<HTMLFormElement, Props>(
   (

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -9,71 +9,74 @@ import type {
 
 import Field from "../Field";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 type Option = OptionHTMLAttributes<HTMLOptionElement>;
 
 /**
  * The props for the Select component.
  */
-export type Props = {
-  /**
-   * The content for caution validation.
-   */
-  caution?: ReactNode;
-  /**
-   * Optional class(es) to pass to the input element.
-   */
-  className?: ClassName;
-  /**
-   * The content for error validation.
-   */
-  error?: ReactNode;
-  /**
-   * Help text to show below the field.
-   */
-  help?: ReactNode;
-  /**
-   * The id of the input.
-   */
-  id?: string;
-  /**
-   * The label for the field.
-   */
-  label?: ReactNode;
-  /**
-   * Optional class(es) to pass to the label component.
-   */
-  labelClassName?: string;
-  /**
-   * Function to run when select value changes.
-   */
-  onChange?: ChangeEventHandler<HTMLSelectElement>;
-  /**
-   * Array of options that the select can choose from.
-   */
-  options?: Option[];
-  /**
-   * Whether the field is required.
-   */
-  required?: boolean;
-  /**
-   * Whether the form field should have a stacked appearance.
-   */
-  stacked?: boolean;
-  /**
-   * The content for success validation.
-   */
-  success?: ReactNode;
-  /**
-   * Whether to focus on the input on initial render.
-   */
-  takeFocus?: boolean;
-  /**
-   * Optional class(es) to pass to the wrapping Field component
-   */
-  wrapperClassName?: string;
-} & SelectHTMLAttributes<HTMLSelectElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content for caution validation.
+     */
+    caution?: ReactNode;
+    /**
+     * Optional class(es) to pass to the input element.
+     */
+    className?: ClassName;
+    /**
+     * The content for error validation.
+     */
+    error?: ReactNode;
+    /**
+     * Help text to show below the field.
+     */
+    help?: ReactNode;
+    /**
+     * The id of the input.
+     */
+    id?: string;
+    /**
+     * The label for the field.
+     */
+    label?: ReactNode;
+    /**
+     * Optional class(es) to pass to the label component.
+     */
+    labelClassName?: string;
+    /**
+     * Function to run when select value changes.
+     */
+    onChange?: ChangeEventHandler<HTMLSelectElement>;
+    /**
+     * Array of options that the select can choose from.
+     */
+    options?: Option[];
+    /**
+     * Whether the field is required.
+     */
+    required?: boolean;
+    /**
+     * Whether the form field should have a stacked appearance.
+     */
+    stacked?: boolean;
+    /**
+     * The content for success validation.
+     */
+    success?: ReactNode;
+    /**
+     * Whether to focus on the input on initial render.
+     */
+    takeFocus?: boolean;
+    /**
+     * Optional class(es) to pass to the wrapping Field component
+     */
+    wrapperClassName?: string;
+  },
+  SelectHTMLAttributes<HTMLSelectElement>
+>;
 
 const generateOptions = (options: Props["options"]) =>
   options.map(({ label, value, ...props }) => (

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -3,58 +3,63 @@ import type { ChangeEventHandler, HTMLProps, ReactNode } from "react";
 
 import Field from "../Field";
 
+import type { PropsWithSpread } from "types";
+
 export const FILLED_COLOR = "#0066CC";
 
-export type Props = {
-  /**
-   * Field caution message.
-   */
-  caution?: ReactNode;
-  /**
-   * Whether to disable the slider and input (if showInput is true).
-   */
-  disabled?: boolean;
-  /**
-   * Field error message.
-   */
-  error?: ReactNode;
-  /**
-   * Field help message.
-   */
-  help?: ReactNode;
-  /**
-   * Field id. Only passed to range input, not to number input.
-   */
-  id?: string;
-  /**
-   * Whether to disable only the input, but not the slider.
-   */
-  inputDisabled?: boolean;
-  /**
-   * Field label.
-   */
-  label?: ReactNode;
-  /**
-   * Maximum value of the slider.
-   */
-  max: number;
-  /**
-   * Minimum value of the slider.
-   */
-  min: number;
-  /**
-   * Change event handler.
-   */
-  onChange: ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Whether the field is required for the form to submit.
-   */
-  required?: boolean;
-  /**
-   * Whether to show a number input with the numerical value next to the slider.
-   */
-  showInput?: boolean;
-} & Omit<HTMLProps<HTMLInputElement>, "label" | "onChange">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Field caution message.
+     */
+    caution?: ReactNode;
+    /**
+     * Whether to disable the slider and input (if showInput is true).
+     */
+    disabled?: boolean;
+    /**
+     * Field error message.
+     */
+    error?: ReactNode;
+    /**
+     * Field help message.
+     */
+    help?: ReactNode;
+    /**
+     * Field id. Only passed to range input, not to number input.
+     */
+    id?: string;
+    /**
+     * Whether to disable only the input, but not the slider.
+     */
+    inputDisabled?: boolean;
+    /**
+     * Field label.
+     */
+    label?: ReactNode;
+    /**
+     * Maximum value of the slider.
+     */
+    max: number;
+    /**
+     * Minimum value of the slider.
+     */
+    min: number;
+    /**
+     * Change event handler.
+     */
+    onChange: ChangeEventHandler<HTMLInputElement>;
+    /**
+     * Whether the field is required for the form to submit.
+     */
+    required?: boolean;
+    /**
+     * Whether to show a number input with the numerical value next to the slider.
+     */
+    showInput?: boolean;
+  },
+  HTMLProps<HTMLInputElement>
+>;
 
 export const Slider = ({
   caution,

--- a/src/components/Strip/Strip.tsx
+++ b/src/components/Strip/Strip.tsx
@@ -6,62 +6,65 @@ import Col from "../Col";
 import type { ColSize } from "../Col/Col";
 import Row from "../Row";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the strip.
-   */
-  children: ReactNode;
-  /**
-   * A background images for the strip.
-   */
-  background?: string;
-  /**
-   * Whether the strip should display borders.
-   */
-  bordered?: boolean;
-  /**
-   * Optional classes for the strip.
-   */
-  className?: ClassName;
-  /**
-   * The width of the column if `includeCol` has been set.
-   */
-  colSize?: ColSize;
-  /**
-   * Whether the strip should be dark.
-   */
-  dark?: boolean;
-  /**
-   * Whether the strip should be deep.
-   */
-  deep?: boolean;
-  /**
-   * The base HTML element of the strip.
-   */
-  element?: ElementType;
-  /**
-   * Whether the strip should wrap the content in a column.
-   */
-  includeCol?: boolean;
-  /**
-   * Whether the strip should be light.
-   */
-  light?: boolean;
-  /**
-   * Optional classes to apply to the row.
-   */
-  rowClassName?: string;
-  /**
-   * Whether the strip should be shallow.
-   */
-  shallow?: boolean;
-  /**
-   * The type of the strip (e.g. "accent" or "image").
-   */
-  type?: string;
-} & Omit<HTMLProps<HTMLElement>, "type">;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the strip.
+     */
+    children: ReactNode;
+    /**
+     * A background images for the strip.
+     */
+    background?: string;
+    /**
+     * Whether the strip should display borders.
+     */
+    bordered?: boolean;
+    /**
+     * Optional classes for the strip.
+     */
+    className?: ClassName;
+    /**
+     * The width of the column if `includeCol` has been set.
+     */
+    colSize?: ColSize;
+    /**
+     * Whether the strip should be dark.
+     */
+    dark?: boolean;
+    /**
+     * Whether the strip should be deep.
+     */
+    deep?: boolean;
+    /**
+     * The base HTML element of the strip.
+     */
+    element?: ElementType;
+    /**
+     * Whether the strip should wrap the content in a column.
+     */
+    includeCol?: boolean;
+    /**
+     * Whether the strip should be light.
+     */
+    light?: boolean;
+    /**
+     * Optional classes to apply to the row.
+     */
+    rowClassName?: string;
+    /**
+     * Whether the strip should be shallow.
+     */
+    shallow?: boolean;
+    /**
+     * The type of the strip (e.g. "accent" or "image").
+     */
+    type?: string;
+  },
+  HTMLProps<HTMLElement>
+>;
 
 const Strip = ({
   background,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,26 +1,29 @@
 import classNames from "classnames";
 import React, { HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the table.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping table element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the table can expand hidden cells.
-   */
-  expanding?: boolean;
-  /**
-   * Whether the table should show card styling on smaller screens.
-   */
-  responsive?: boolean;
-} & HTMLProps<HTMLTableElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the table.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping table element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the table can expand hidden cells.
+     */
+    expanding?: boolean;
+    /**
+     * Whether the table should show card styling on smaller screens.
+     */
+    responsive?: boolean;
+  },
+  HTMLProps<HTMLTableElement>
+>;
 
 const Table = ({
   children,

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -1,30 +1,33 @@
 import classNames from "classnames";
 import React, { HTMLProps, ReactNode } from "react";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * The content of the table cell.
-   */
-  children?: ReactNode;
-  /**
-   * Optional class(es) to pass to the wrapping td element.
-   */
-  className?: ClassName;
-  /**
-   * Whether the cell is an expanded cell.
-   */
-  expanding?: boolean;
-  /**
-   * Whether content of the cell should be able to overflow, e.g. a dropdown.
-   */
-  hasOverflow?: boolean;
-  /**
-   * Whether the cell is currently hidden.
-   */
-  hidden?: boolean;
-} & HTMLProps<HTMLTableCellElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the table cell.
+     */
+    children?: ReactNode;
+    /**
+     * Optional class(es) to pass to the wrapping td element.
+     */
+    className?: ClassName;
+    /**
+     * Whether the cell is an expanded cell.
+     */
+    expanding?: boolean;
+    /**
+     * Whether content of the cell should be able to overflow, e.g. a dropdown.
+     */
+    hasOverflow?: boolean;
+    /**
+     * Whether the cell is currently hidden.
+     */
+    hidden?: boolean;
+  },
+  HTMLProps<HTMLTableCellElement>
+>;
 
 const TableCell = ({
   children,

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -1,17 +1,20 @@
 import React, { HTMLProps, ReactNode } from "react";
 
-import { SortDirection } from "types";
+import { PropsWithSpread, SortDirection } from "types";
 
-export type Props = {
-  /**
-   * The content of the table header.
-   */
-  children?: ReactNode;
-  /**
-   * The direction of sorting, if applicable.
-   */
-  sort?: SortDirection;
-} & HTMLProps<HTMLTableHeaderCellElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the table header.
+     */
+    children?: ReactNode;
+    /**
+     * The direction of sorting, if applicable.
+     */
+    sort?: SortDirection;
+  },
+  HTMLProps<HTMLTableHeaderCellElement>
+>;
 
 const TableHeader = ({ children, sort, ...props }: Props): JSX.Element => {
   return (

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -1,12 +1,17 @@
 import type { HTMLProps, ReactNode } from "react";
 import React from "react";
 
-export type Props = {
-  /**
-   * The content of the table row.
-   */
-  children: ReactNode;
-} & HTMLProps<HTMLTableRowElement>;
+import type { PropsWithSpread } from "types";
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content of the table row.
+     */
+    children: ReactNode;
+  },
+  HTMLProps<HTMLTableRowElement>
+>;
 
 const TableRow = ({ children, ...trProps }: Props): JSX.Element => (
   <tr role="row" {...trProps}>

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -4,65 +4,68 @@ import type { HTMLAttributes, ReactNode } from "react";
 
 import Field from "../Field";
 
-import type { ClassName } from "types";
+import type { ClassName, PropsWithSpread } from "types";
 
 /**
  * The props for the Textarea component.
  */
-export type Props = {
-  /**
-   * The content for caution validation.
-   */
-  caution?: ReactNode;
-  /**
-   * Optional class(es) to pass to the textarea element.
-   */
-  className?: ClassName;
-  /**
-   * The content for error validation.
-   */
-  error?: ReactNode;
-  /**
-   * Whether the textarea should grow to fit the content automatically.
-   */
-  grow?: boolean;
-  /**
-   * Help text to show below the field.
-   */
-  help?: ReactNode;
-  /**
-   * The id of the textarea.
-   */
-  id?: string;
-  /**
-   * The label for the field.
-   */
-  label?: ReactNode;
-  /**
-   * Optional class(es) to pass to the label component.
-   */
-  labelClassName?: string;
-  /**
-   * Whether the field is required.
-   */
-  required?: boolean;
-  /**
-   * Whether the form field should have a stacked appearance.
-   */
-  stacked?: boolean;
-  /**
-   * The content for success validation.
-   */
-  success?: ReactNode;
-  /**
-   * Whether to focus on the input on initial render.
-   */
-  takeFocus?: boolean;
-  /**
-   * Optional class(es) to pass to the wrapping Field component
-   */
-  wrapperClassName?: string;
-} & HTMLAttributes<HTMLTextAreaElement>;
+export type Props = PropsWithSpread<
+  {
+    /**
+     * The content for caution validation.
+     */
+    caution?: ReactNode;
+    /**
+     * Optional class(es) to pass to the textarea element.
+     */
+    className?: ClassName;
+    /**
+     * The content for error validation.
+     */
+    error?: ReactNode;
+    /**
+     * Whether the textarea should grow to fit the content automatically.
+     */
+    grow?: boolean;
+    /**
+     * Help text to show below the field.
+     */
+    help?: ReactNode;
+    /**
+     * The id of the textarea.
+     */
+    id?: string;
+    /**
+     * The label for the field.
+     */
+    label?: ReactNode;
+    /**
+     * Optional class(es) to pass to the label component.
+     */
+    labelClassName?: string;
+    /**
+     * Whether the field is required.
+     */
+    required?: boolean;
+    /**
+     * Whether the form field should have a stacked appearance.
+     */
+    stacked?: boolean;
+    /**
+     * The content for success validation.
+     */
+    success?: ReactNode;
+    /**
+     * Whether to focus on the input on initial render.
+     */
+    takeFocus?: boolean;
+    /**
+     * Optional class(es) to pass to the wrapping Field component
+     */
+    wrapperClassName?: string;
+  },
+  HTMLAttributes<HTMLTextAreaElement>
+>;
 
 const Textarea = ({
   caution,

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export type { TooltipProps } from "./components/Tooltip";
 export type {
   ClassName,
   Headings,
+  PropsWithSpread,
   SortDirection,
   SubComponentProps,
   TSFixMe,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,21 @@
+/**
+ * This type should be used for all className props in order to ensure
+ * consistency across components.
+ */
 export type ClassName = string | null;
+/**
+ * The allowable heading levels.
+ */
 export type Headings = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+/**
+ * This type can be used when defining props that also spread the props of
+ * something else. It ensures that the defined component props are never
+ * overwritten by the spread props.
+ */
+export type PropsWithSpread<P, H> = P & Omit<H, keyof P>;
+/**
+ * The allowable sort directions e.g. for a sortable table.
+ */
 export type SortDirection = "none" | "ascending" | "descending";
 /**
  * This type can be used when passing props to a sub component. It makes all
@@ -12,5 +28,14 @@ export type SubComponentProps<P> = Partial<P> & {
   // https://github.com/microsoft/TypeScript/issues/28960
   [prop: string]: unknown;
 };
+/**
+ * This type is simply an alias for the 'any' type and should be used sparingly,
+ * if at all.
+ */
 export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+/**
+ * This type allows for converting an object const into an enum-like construct,
+ * e.g. value: ValueOf<typeof EnumLike> will only allow value to be a value
+ * defined in EnumLike.
+ */
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
## Done

- Added `PropsWithSpread` type that ensures that defined component props are never overwritten by a subsequent prop spread
- Added descriptions to some base types

## QA
### QA steps

- Pull this branch and open `SearchBox.tsx` in VSCode
- Hover over the props in the component function argument and check that the `onChange`, `onSubmit` and `value` props are typed according to the `Props` definition.
