### PR TITLE
Add className prop to Modal

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -52,4 +52,9 @@ describe("Modal ", () => {
     const wrapper = shallow(<Modal title="some title">Bare bones.</Modal>);
     expect(wrapper.find(".p-modal__close")).toEqual({});
   });
+
+  it("can pass extra classes to the wrapper", () => {
+    const wrapper = shallow(<Modal className="extra-class">Bare bones.</Modal>);
+    expect(wrapper.prop("className").includes("extra-class")).toBe(true);
+  });
 });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,30 +1,42 @@
+import classNames from "classnames";
 import { nanoid } from "nanoid";
-import React, { ReactElement, ReactNode, useRef, useEffect } from "react";
+import React, { ReactElement, useRef, useEffect } from "react";
+import type { HTMLProps, ReactNode } from "react";
+import { ClassName, PropsWithSpread } from "types";
 
-export type Props = {
-  /**
-   * Buttons to display underneath the main modal content.
-   */
-  buttonRow?: ReactNode | null;
-  /**
-   * The content of the modal.
-   */
-  children: ReactNode;
-  /**
-   * Function to handle closing the modal.
-   */
-  close?: () => void | null;
-  /**
-   * The title of the modal.
-   */
-  title?: ReactNode | null;
-};
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Buttons to display underneath the main modal content.
+     */
+    buttonRow?: ReactNode | null;
+    /**
+     * Optional class(es) to apply to the wrapping element.
+     */
+    className?: ClassName;
+    /**
+     * The content of the modal.
+     */
+    children: ReactNode;
+    /**
+     * Function to handle closing the modal.
+     */
+    close?: () => void | null;
+    /**
+     * The title of the modal.
+     */
+    title?: ReactNode | null;
+  },
+  HTMLProps<HTMLDivElement>
+>;
 
 export const Modal = ({
   buttonRow,
   children,
+  className,
   close,
   title,
+  ...wrapperProps
 }: Props): ReactElement => {
   const descriptionId = useRef(nanoid());
   const titleId = useRef(nanoid());
@@ -50,7 +62,11 @@ export const Modal = ({
   }, [close]);
 
   return (
-    <div className="p-modal" onClick={close}>
+    <div
+      className={classNames("p-modal", className)}
+      onClick={close}
+      {...wrapperProps}
+    >
       <section
         className="p-modal__dialog"
         role="dialog"


### PR DESCRIPTION
## Done

- Add className prop to Modal and spread to the div.

## QA

N/A

## Fixes

Fixes: #565.
