### PR TITLE
add aria-invalid to Input when there's an error

### DIFF
--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -32,4 +32,14 @@ describe("Input ", () => {
     const wrapper = mount(<Input takeFocus />, { attachTo: container });
     expect(wrapper.find("input").getDOMNode()).toBe(document.activeElement);
   });
+
+  it("sets aria-invalid to false when there is no error", () => {
+    const wrapper = mount(<Input type="text" />);
+    expect(wrapper.find("input").prop("aria-invalid")).toBe(false);
+  });
+
+  it("sets aria-invalid to true when there is an error", () => {
+    const wrapper = mount(<Input type="text" error="Incorrect value" />);
+    expect(wrapper.find("input").prop("aria-invalid")).toBe(true);
+  });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -107,6 +107,7 @@ const Input = ({
         id={id}
         ref={inputRef}
         type={type}
+        aria-invalid={!!error}
         {...inputProps}
       />
     </Field>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -20,7 +20,7 @@ export type Props = PropsWithSpread<
      */
     className?: ClassName;
     /**
-     * The content for error validation.
+     * The content for error validation message. Controls the value of aria-invalid attribute.
      */
     error?: ReactNode;
     /**

--- a/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Input  renders 1`] = `
   labelFirst={true}
 >
   <input
+    aria-invalid={false}
     className="p-form-validation__input"
     id="test-id"
     type="text"


### PR DESCRIPTION
## Done

- add `aria-invalid="true"` to Input when there's an error
  - add tests

## Before
![image](https://user-images.githubusercontent.com/7452681/142187169-6413b6f3-6ab9-4276-b4ac-acf256bb9d4e.png)

## After
![image](https://user-images.githubusercontent.com/7452681/142187007-d678dd2e-f762-4bc8-ba92-8ec8832852d2.png)


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: #639 .
