### PR TITLE
Prevent password toggle component submitting form

### DIFF
--- a/src/components/PasswordToggle/PasswordToggle.tsx
+++ b/src/components/PasswordToggle/PasswordToggle.tsx
@@ -50,6 +50,10 @@ export type Props = PropsWithSpread<
      */
     success?: ReactNode;
     /**
+     * The content for success validation.
+     */
+    type?: "submit" | "reset" | "button";
+    /**
      * Optional class(es) to pass to the wrapping Field component
      */
     wrapperClassName?: string;
@@ -69,6 +73,7 @@ const PasswordToggle = React.forwardRef<HTMLInputElement, Props>(
       readOnly,
       required,
       success,
+      type,
       wrapperClassName,
       ...inputProps
     },
@@ -99,6 +104,7 @@ const PasswordToggle = React.forwardRef<HTMLInputElement, Props>(
           </Label>
           <Button
             appearance="base"
+            type={type ? type : "button"}
             className="u-no-margin--bottom"
             hasIcon
             aria-controls={id}


### PR DESCRIPTION
## Done

- Add new `type` prop to password toggle component
- Set default `type=button` to prevent the button submitting form

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Add the`<PasswordToggle>` component to the <Form> and don't include a type. Check the form doesn't submit when the password toggle button is used. 

## Fixes

Fixes: #663 
