### PR TITLE
Pass required to input element

### DIFF
--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -42,4 +42,9 @@ describe("Input ", () => {
     const wrapper = mount(<Input type="text" error="Incorrect value" />);
     expect(wrapper.find("input").prop("aria-invalid")).toBe(true);
   });
+
+  it("sets required field on input", () => {
+    const wrapper = mount(<Input type="text" required />);
+    expect(wrapper.find("input").prop("required")).toBe(true);
+  });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -106,6 +106,7 @@ const Input = ({
         className={classNames("p-form-validation__input", className)}
         id={id}
         ref={inputRef}
+        required={required}
         type={type}
         aria-invalid={!!error}
         {...inputProps}


### PR DESCRIPTION
## Done

- Pass `required` to input element (currently it's only in the field component).

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Check required exits on `input` element

## Fixes

Fixes: #638  .
