### PR TITLE
Update pagination button to use new icon

### DIFF
--- a/src/components/PaginationButton/PaginationButton.tsx
+++ b/src/components/PaginationButton/PaginationButton.tsx
@@ -34,7 +34,7 @@ const PaginationButton = ({
         disabled={disabled}
         onClick={onClick}
       >
-        <i className="p-icon--contextual-menu">{label}</i>
+        <i className="p-icon--chevron-down">{label}</i>
       </button>
     </li>
   );


### PR DESCRIPTION
## Done

- Replaced `p-icon--contextual-menu` with `p-icon--chevron-down`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Check the pagination buttons https://react-components-675.demos.haus/?path=/story/pagination--default-story aren't broken 

## Fixes

Fixes: [#1168](https://github.com/canonical-web-and-design/vanilla-squad/issues/1168) .
