### PR TITLE
Remove external link

### DIFF
--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -41,16 +41,6 @@ Links are used to embed actions or pathways to more information, allowing users 
   </Story>
 </Canvas>
 
-### External
-
-<Canvas>
-  <Story name="External">
-    <p>
-      <Link external>Get started with Juju</Link>
-    </p>
-  </Story>
-</Canvas>
-
 ### Soft
 
 <Canvas>

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -9,11 +9,6 @@ describe("Link ", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("can be an external link", () => {
-    const wrapper = shallow(<Link external={true}>Test content</Link>);
-    expect(wrapper.prop("className").includes("p-link--external")).toBe(true);
-  });
-
   it("can be an inverted link", () => {
     const wrapper = shallow(<Link inverted={true}>Test content</Link>);
     expect(wrapper.prop("className").includes("p-link--inverted")).toBe(true);

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -15,10 +15,6 @@ export type Props = PropsWithSpread<
      */
     className?: ClassName;
     /**
-     * Whether the link should have external styling.
-     */
-    external?: boolean;
-    /**
      * Whether the link should have inverted styling.
      */
     inverted?: boolean;
@@ -37,7 +33,6 @@ export type Props = PropsWithSpread<
 const Link = ({
   children,
   className,
-  external = false,
   href = "#",
   inverted = false,
   soft = false,
@@ -47,7 +42,6 @@ const Link = ({
   const link = (
     <a
       className={classNames(className, {
-        "p-link--external": external,
         "p-link--inverted": inverted,
         "p-link--soft": soft,
         "p-top__link": top,


### PR DESCRIPTION
## Done

- Remove external link option from links
- Remove test

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Check the external link example no longer exists

## Fixes

Fixes: #[1170](https://github.com/canonical-web-and-design/vanilla-squad/issues/1170) .
