### PR TITLE
Remove specific node versions from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,6 @@
   "resolutions": {
     "postcss": "^8.3.11"
   },
-  "engines": {
-    "node": "^14 || ^16 || ^18"
-  },
   "peerDependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
## Done

For the sake of renovate we specify the expected node versions in renovate.json, so specifying them in package.json is redundant and unnecessary.

https://github.com/canonical-web-and-design/vanilla-framework/blob/f28cda8560d24f67b14b0ccc93ae3303788a0736/renovate.json#L18-L20


Fixes canonical-web-and-design/vanilla-squad#1187