### PR TITLE
Fix extra padding in search box nav example

### DIFF
--- a/src/components/SearchBox/SearchBox.stories.mdx
+++ b/src/components/SearchBox/SearchBox.stories.mdx
@@ -50,7 +50,7 @@ state and the `value` from state.
       <div className="p-navigation__row--full-width">
         <div className="p-navigation__banner">
           <div className="p-navigation__logo">
-            <a className="p-navigation__link" href="#">
+            <a className="p-navigation__item" href="#">
               <img
                 className="p-navigation__image"
                 src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg"


### PR DESCRIPTION
## Done

- The logo was using `p-navigation__link` instead of `p-navigation__item`. This fixes the padding.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Check this [demo](https://react-components-656.demos.haus/?path=/story/searchbox--navigation) which is using vanilla 3.0, check that changing the classname fixes the padding 

## Fixes

Fixes: #679 
