### PR TITLE
Replace p-icon--contextual-menu on table

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -295,7 +295,7 @@ const ContextualMenu = <L,>({
           {hasToggleIcon ? (
             <i
               className={classNames(
-                "p-icon--contextual-menu p-contextual-menu__indicator",
+                "p-icon--chevron-down p-contextual-menu__indicator",
                 {
                   "is-light": ["negative", "positive"].includes(
                     toggleAppearance


### PR DESCRIPTION
## Done

- Replace `p-icon--contextual-menu` with `p-icon--chevron-down`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- Check this [demo](https://react-components-656.demos.haus/?path=/docs/maintable--overflow) and check the chevron appears when the classname is changed as mentioned above. I've QA'd this on the vanilla 3.0 branch and changing the classname here also fixes the [button](https://react-components-656.demos.haus/?path=/story/contextualmenu--toggle)

## Fixes

Fixes: [#4205](https://github.com/canonical-web-and-design/vanilla-framework/issues/4205) .
