### PR TITLE
Replace p-label--new

### DIFF
--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -115,7 +115,7 @@ If you want to display lists in a way that is more visually distinctive than the
       items={[
         { content: <h3>Documentation</h3> },
         {
-          content: <span className="p-label--new">New</span>,
+          content: <span className="p-label--positive">New</span>,
           className: "u-vertically-center u-align--right",
         },
       ]}


### PR DESCRIPTION
## Done

- Replace `p-label--new` with `p-label--positive`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- See [here](https://react-components-656.demos.haus/?path=/story/list--stretch), the demo of 3.0 shows the label is broken. Change the classname to `p-label--positive` and see the correct label

## Fixes

Fixes: #682  .
