### PR TITLE
Changed search term item's tag

### DIFF
--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -290,7 +290,11 @@ const SearchAndFilter = ({
                 role="button"
                 tabIndex={0}
               >
-                Search for <span className="p-search-and-filter__search-query">{searchTerm}</span>...
+                Search for{" "}
+                <span className="p-search-and-filter__search-query">
+                  {searchTerm}
+                </span>
+                ...
               </div>
             )}
             {filterPanelData.map((filterPanelSectionData) => {

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -290,7 +290,7 @@ const SearchAndFilter = ({
                 role="button"
                 tabIndex={0}
               >
-                Search for <strong>{searchTerm}</strong>...
+                Search for <span className="p-search-and-filter__search-query">{searchTerm}</span>...
               </div>
             )}
             {filterPanelData.map((filterPanelSectionData) => {


### PR DESCRIPTION
## Done

- Search query is wrapped with span tag with a class name `p-search-and-filter__search-query`.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open [demo](https://react-components-696.demos.haus/?path=/docs/search-and-filter--default-story#search-and-filter)
- Enter text to the default search and filter component.
- Verify the search term is bold.
- Verify search term has "p-search-and-filter__search-query" class.

## Fixes

Fixes: #616 
