### PR TITLE
Spread <span> props on Spinner component

### DIFF
--- a/src/components/Spinner/Spinner.test.tsx
+++ b/src/components/Spinner/Spinner.test.tsx
@@ -38,4 +38,12 @@ describe("<Spinner />", () => {
 
     expect(component.find("i").first().hasClass("is-light")).toEqual(true);
   });
+
+  it("renders a custom aria-label", () => {
+    const component = shallow(<Spinner aria-label="custom loading text" />);
+
+    expect(component.find("span").first().props()["aria-label"]).toEqual(
+      "custom loading text"
+    );
+  });
 });

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { HTMLProps } from "react";
 import classNames from "classnames";
 
 import type { ClassName } from "types";
@@ -16,10 +16,15 @@ export type Props = {
    * Text to display next to the spinner.
    */
   text?: string;
-};
+} & HTMLProps<HTMLSpanElement>;
 
-const Spinner = ({ className, text, isLight = false }: Props): JSX.Element => (
-  <span className={classNames(className, "p-text--default")}>
+const Spinner = ({
+  className,
+  text,
+  isLight = false,
+  ...props
+}: Props): JSX.Element => (
+  <span {...props} className={classNames(className, "p-text--default")}>
     <i
       className={classNames("p-icon--spinner", "u-animation--spin", {
         "is-light": isLight,


### PR DESCRIPTION
## Done

- Spread <span> props on Spinner component
- This will allow adding an aria-label

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Add an aria-label to the spinner component and verify it's added to the outer span element correctly.

## Fixes

Fixes: #651 .
