### PR TITLE
Add data-heading as default to responsive columns

### DIFF
--- a/src/components/MainTable/MainTable.stories.mdx
+++ b/src/components/MainTable/MainTable.stories.mdx
@@ -385,40 +385,44 @@ If the table cell may have overflowing content (such as contextual menu) use `ha
   <Story name="Responsive">
     <MainTable
       headers={[
-        { content: "Name" },
+        {
+          content: (
+            <span>
+              Name <i class="p-icon--information"></i>
+            </span>
+          ),
+          heading: "Name",
+        },
         { content: "Users", className: "u-align--right" },
         { content: "Units", className: "u-align--right" },
       ]}
       rows={[
         {
           columns: [
-            { content: "Ready", role: "rowheader", "aria-label": "Name" },
-            { content: 1, "aria-label": "Users", className: "u-align--right" },
+            { content: "Ready", role: "rowheader" },
+            { content: 1, className: "u-align--right" },
             {
               content: "1 GiB",
-              "aria-label": "Units",
               className: "u-align--right",
             },
           ],
         },
         {
           columns: [
-            { content: "Ready", role: "rowheader", "aria-label": "Name" },
-            { content: 1, "aria-label": "Users", className: "u-align--right" },
+            { content: "Ready", role: "rowheader" },
+            { content: 1, className: "u-align--right" },
             {
               content: "1 GiB",
-              "aria-label": "Units",
               className: "u-align--right",
             },
           ],
         },
         {
           columns: [
-            { content: "Ready", role: "rowheader", "aria-label": "Name" },
-            { content: 1, "aria-label": "Users", className: "u-align--right" },
+            { content: "Ready", role: "rowheader" },
+            { content: 1, className: "u-align--right" },
             {
               content: "1 GiB",
-              "aria-label": "Units",
               className: "u-align--right",
             },
           ],

--- a/src/components/MainTable/MainTable.stories.mdx
+++ b/src/components/MainTable/MainTable.stories.mdx
@@ -388,7 +388,7 @@ If the table cell may have overflowing content (such as contextual menu) use `ha
         {
           content: (
             <span>
-              Name <i class="p-icon--information"></i>
+              Name <i className="p-icon--information"></i>
             </span>
           ),
           heading: "Name",

--- a/src/components/MainTable/MainTable.test.tsx
+++ b/src/components/MainTable/MainTable.test.tsx
@@ -15,7 +15,14 @@ describe("MainTable", () => {
       { content: "Status" },
       { content: "Cores", className: "u-align--right" },
       { content: "RAM", className: "u-align--right" },
-      { content: "Disks", className: "u-align--right" },
+      {
+        content: (
+          <span>
+            Disks <i className="p-icon--information"></i>
+          </span>
+        ),
+        className: "u-align--right",
+      },
     ];
     rows = [
       {
@@ -98,6 +105,35 @@ describe("MainTable", () => {
       <MainTable headers={headers} responsive={true} rows={rows} />
     );
     expect(wrapper.find("Table").prop("responsive")).toBe(true);
+  });
+
+  it("contains data-heading attribute equal to heading on columns in responsive table", () => {
+    const wrapper = shallow(
+      <MainTable headers={headers} responsive={true} rows={rows} />
+    );
+
+    expect(wrapper.find("TableCell").first().prop("data-heading")).toEqual(
+      "Status"
+    );
+  });
+
+  it("doesn't contain data-heading attribute if there is no heading", () => {
+    const wrapper = shallow(<MainTable responsive={true} rows={rows} />);
+
+    expect(wrapper.find("TableCell").first().prop("data-heading")).toBe(
+      undefined
+    );
+  });
+
+  it("uses heading prop for data-heading if there are is no heading for that column", () => {
+    headers[3].heading = "Replacement";
+    const wrapper = shallow(
+      <MainTable headers={headers} responsive={true} rows={rows} />
+    );
+
+    expect(wrapper.find("TableCell").last().prop("data-heading")).toEqual(
+      "Replacement"
+    );
   });
 
   it("can be paginated", () => {

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -244,8 +244,8 @@ const generateRows = (
       index
     ) => {
       const cellItems = columns.map(({ content, ...cellProps }, index) => {
-        const headerContent = headers[index]["content"];
-        const headerReplacement = headers[index]["heading"];
+        const headerContent = headers && headers[index]["content"];
+        const headerReplacement = headers && headers[index]["heading"];
 
         return (
           <TableCell

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -24,6 +24,10 @@ export type MainTableHeader = PropsWithSpread<
      * A key to sort the rows by. It should match a key given to the row `sortData`.
      */
     sortKey?: string | null;
+    /**
+     * Replacement value for data-heading if content is not a string.
+     */
+    heading?: string;
   },
   HTMLProps<HTMLTableHeaderCellElement>
 >;
@@ -191,6 +195,8 @@ const generateRows = (
   currentSortKey: MainTableHeader["sortKey"],
   emptyStateMsg: ReactNode,
   expanding: Props["expanding"],
+  responsive: Props["responsive"],
+  headers: Props["headers"],
   paginate: Props["paginate"],
   rows: Props["rows"],
   currentPage: number,
@@ -237,12 +243,26 @@ const generateRows = (
       { columns, expanded, expandedContent, key, sortData, ...rowProps },
       index
     ) => {
-      const cellItems = columns.map(({ content, ...cellProps }, index) => (
-        <TableCell key={index} {...cellProps}>
-          {content}
-        </TableCell>
-      ));
+      const cellItems = columns.map(({ content, ...cellProps }, index) => {
+        const headerContent = headers[index]["content"];
+        const headerReplacement = headers[index]["heading"];
 
+        return (
+          <TableCell
+            key={index}
+            data-heading={
+              responsive
+                ? typeof headerContent === "string"
+                  ? headerContent
+                  : headerReplacement
+                : null
+            }
+            {...cellProps}
+          >
+            {content}
+          </TableCell>
+        );
+      });
       // if key was not provided as a prop, use row's index instead
       if (key === null || typeof key === "undefined") {
         key = index;
@@ -318,6 +338,8 @@ const MainTable = ({
             currentSortKey,
             emptyStateMsg,
             expanding,
+            responsive,
+            headers,
             paginate,
             rows,
             currentPage,

--- a/src/components/MainTable/__snapshots__/MainTable.test.tsx.snap
+++ b/src/components/MainTable/__snapshots__/MainTable.test.tsx.snap
@@ -26,7 +26,12 @@ exports[`MainTable renders 1`] = `
           className="u-align--right"
           key="3"
         >
-          Disks
+          <span>
+            Disks 
+            <i
+              className="p-icon--information"
+            />
+          </span>
         </TableHeader>
       </TableRow>
     </thead>
@@ -35,6 +40,7 @@ exports[`MainTable renders 1`] = `
         key="0"
       >
         <TableCell
+          data-heading={null}
           key="0"
           role="rowheader"
         >
@@ -42,18 +48,21 @@ exports[`MainTable renders 1`] = `
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="1"
         >
           1
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="2"
         >
           1 GiB
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="3"
         >
           2
@@ -63,6 +72,7 @@ exports[`MainTable renders 1`] = `
         key="1"
       >
         <TableCell
+          data-heading={null}
           key="0"
           role="rowheader"
         >
@@ -70,18 +80,21 @@ exports[`MainTable renders 1`] = `
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="1"
         >
           1
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="2"
         >
           1 GiB
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="3"
         >
           2
@@ -91,6 +104,7 @@ exports[`MainTable renders 1`] = `
         key="2"
       >
         <TableCell
+          data-heading={null}
           key="0"
           role="rowheader"
         >
@@ -98,18 +112,21 @@ exports[`MainTable renders 1`] = `
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="1"
         >
           8
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="2"
         >
           3.9 GiB
         </TableCell>
         <TableCell
           className="u-align--right"
+          data-heading={null}
           key="3"
         >
           3


### PR DESCRIPTION
## Done

- Add data-heading to responsive table
- Update example to include HTML for content instead of string
- Add tests

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check responsive table example `<td>` have correct data-heading attributes
- Check other tables don't
- Check tests pass

## Fixes

Fixes: #701  .
