### PR TITLE
feat: add inline prop support to checkbox & radio

### DIFF
--- a/src/components/CheckableInput/CheckableInput.test.tsx
+++ b/src/components/CheckableInput/CheckableInput.test.tsx
@@ -33,6 +33,17 @@ describe("CheckableInput ", () => {
     expect(wrapper.find(".p-radio.is-required").length).toBe(1);
   });
 
+  it("can apply the --inline modifier class", () => {
+    const wrapper = shallow(
+      <CheckableInput
+        inputType="radio"
+        label="Test required"
+        inline
+      ></CheckableInput>
+    );
+    expect(wrapper.find(".p-radio--inline").length).toBe(1);
+  });
+
   it("can set a checkbox to indeterminate state", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/src/components/CheckableInput/CheckableInput.tsx
+++ b/src/components/CheckableInput/CheckableInput.tsx
@@ -19,6 +19,10 @@ export type Props = PropsWithSpread<
      * Whether the input element should display in indeterminate state.
      */
     indeterminate?: boolean;
+    /**
+     * Ensures the input and the label text are properly aligned with other inline text.
+     */
+    inline?: boolean;
   },
   // We explicitly omit "type" otherwise it's possible to overwrite "inputType".
   // Might want to consider just using "type" instead.
@@ -40,9 +44,12 @@ const CheckableInput = ({
 
   return (
     <label
-      className={classNames(`p-${inputType}`, {
-        "is-required": checkboxProps.required,
-      })}
+      className={classNames(
+        `p-${inputType}${checkboxProps.inline ? "--inline" : ""}`,
+        {
+          "is-required": checkboxProps.required,
+        }
+      )}
     >
       <input
         aria-labelledby={inputId}

--- a/src/components/CheckboxInput/CheckboxInput.stories.mdx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.mdx
@@ -22,6 +22,11 @@ import CheckboxInput from "./CheckboxInput";
         type: "boolean",
       },
     },
+    inline: {
+      control: {
+        type: "boolean",
+      },
+    },
     indeterminate: {
       control: {
         type: "boolean",
@@ -76,6 +81,14 @@ Use the checkbox component to select one or more options.
 <Canvas>
   <Story name="Required">
     <CheckboxInput label="Required" required></CheckboxInput>
+  </Story>
+</Canvas>
+
+### Inline
+
+<Canvas>
+  <Story name="Inline">
+    <CheckboxInput label="Inline" inline></CheckboxInput>
   </Story>
 </Canvas>
 

--- a/src/components/CheckboxInput/CheckboxInput.test.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.test.tsx
@@ -1,13 +1,11 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import CheckboxInput from "./CheckboxInput";
 
-describe("CheckboxInput ", () => {
-  it("renders a checkbox", () => {
-    const wrapper = mount(
-      <CheckboxInput label="Test checkbox"></CheckboxInput>
-    );
-    expect(wrapper.find("input.p-checkbox__input").length).toBe(1);
-  });
+it("renders a checkbox", () => {
+  render(<CheckboxInput label="Test checkbox"></CheckboxInput>);
+  expect(
+    screen.getByRole("checkbox", { name: "Test checkbox" })
+  ).toBeInTheDocument();
 });

--- a/src/components/RadioInput/RadioInput.stories.mdx
+++ b/src/components/RadioInput/RadioInput.stories.mdx
@@ -22,6 +22,11 @@ import RadioInput from "./RadioInput";
         type: "boolean",
       },
     },
+    inline: {
+      control: {
+        type: "boolean",
+      },
+    },
     indeterminate: {
       control: {
         type: "boolean",
@@ -76,5 +81,13 @@ Use radio buttons to select one of the given set of options.
 <Canvas>
   <Story name="Required">
     <RadioInput label="Required" name="RadioInput" required></RadioInput>
+  </Story>
+</Canvas>
+
+### Inline
+
+<Canvas>
+  <Story name="Inline">
+    <RadioInput label="Inline" name="RadioInput" inline></RadioInput>
   </Story>
 </Canvas>

--- a/src/components/RadioInput/RadioInput.test.tsx
+++ b/src/components/RadioInput/RadioInput.test.tsx
@@ -1,13 +1,9 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import RadioInput from "./RadioInput";
 
-describe("RadioInput ", () => {
-  it("renders a radio input", () => {
-    const wrapper = mount(
-      <RadioInput label="Test radio" name="Radio test"></RadioInput>
-    );
-    expect(wrapper.find("input.p-radio__input").length).toBe(1);
-  });
+it("renders a radio input", () => {
+  render(<RadioInput label="Test radio" name="Radio test"></RadioInput>);
+  expect(screen.getByRole("radio", { name: "Test radio" })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Done

- add inline prop support to checkbox & radio

related docs in vanillaframework.io:
- https://vanillaframework.io/docs/base/forms#inline-checkbox
- https://vanillaframework.io/docs/base/forms#inline-radio-button

## Screenshots
![Kapture 2022-02-23 at 15 34 34](https://user-images.githubusercontent.com/7452681/155340290-2fe90d03-2d54-499c-8b72-9f6e6159e315.gif)
![Kapture 2022-02-23 at 15 35 20](https://user-images.githubusercontent.com/7452681/155340420-24d07a37-7d20-47b4-94df-2f6bff7a8a5f.gif)


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
