### PR TITLE
test: add eslint-plugin-testing-library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   parser: "@babel/eslint-parser",
-  plugins: ["react", "prettier", "cypress"],
+  plugins: ["react", "prettier", "cypress", "testing-library"],
   extends: [
     "react-app", // Use the recommended rules from CRA.
     "plugin:cypress/recommended",
@@ -67,6 +67,15 @@ module.exports = {
         react: {
           version: "detect",
         },
+      },
+    },
+    {
+      files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+      extends: ["plugin:testing-library/react"],
+      rules: {
+        "testing-library/no-node-access": "warn",
+        "testing-library/no-container": "warn",
+        "testing-library/no-render-in-setup": "warn",
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
+    "eslint-plugin-testing-library": "5.0.5",
     "jest": "27.4.7",
     "npm-package-json-lint": "5.4.2",
     "prettier": "2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6101,7 +6101,7 @@ eslint-plugin-react@7.28.0, eslint-plugin-react@^7.27.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-testing-library@^5.0.1:
+eslint-plugin-testing-library@5.0.5, eslint-plugin-testing-library@^5.0.1:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.5.tgz#5757961ec20a6ca8b0992d2c5487db1b51612d8d"
   integrity sha512-0j355vJpJCE/2g+aayIgJRUB6jBVqpD5ztMLGcadR1PgrgGPnPxN1HJuOAsAAwiMo27GwRnpJB8KOQzyNuNZrw==


### PR DESCRIPTION
## Done

- add eslint-plugin-testing-library
  - rules that have existing violations in some react-components tests are set to "warn" instead of "error"

## Why is this needed
This will help follow testing-library best practices.

### Currently violated rules for reference
These violations aren't necessarily a real issue (except the single violation of "render" in "beforeEach").
We might want to leave them as is or update in a separate PR.

```
/react-components/src/components/Modal/Modal.test.tsx
  64:16  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  89:39  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  93:40  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  97:39  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/react-components/src/components/SummaryButton/SummaryButton.test.tsx
  18:22  warning  Avoid direct Node access. Prefer using the methods from Testing Library                              testing-library/no-node-access
  27:12  warning  Avoid using container methods. Prefer using the methods from Testing Library, such as "getByRole()"  testing-library/no-container
  27:22  warning  Avoid direct Node access. Prefer using the methods from Testing Library                              testing-library/no-node-access

/react-components/src/hooks/useListener.test.ts
  34:7  warning  Forbidden usage of `render` within testing framework `beforeEach` setup  testing-library/no-render-in-setup

✖ 8 problems (0 errors, 8 warnings)
```

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
