### PR TITLE
feat: customisation of specific headers, rows and cells in ModularTable

### DIFF
--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -35,7 +35,7 @@ In addition to standard column propeties from [`useTable`](https://react-table.t
 ##### Class names
 
 Custom `className` can be used to provide a specific CSS class name that will be added to all cells in given column.
-You can also provide a `getCellProps` to customise class names for specific cells. More on this in [`useTable - cell properties`](https://react-table.tanstack.com/docs/api/useTable#cell-properties).
+You can also provide `getHeaderProps`, `getRowProps` and `getCellProps` to resolve additional custom props for a specific element. More on this in [`useTable - cell properties`](https://react-table.tanstack.com/docs/api/useTable#cell-properties).
 
 ```js
 getCellProps={({ value, column }) => ({

--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -35,8 +35,12 @@ In addition to standard column propeties from [`useTable`](https://react-table.t
 ##### Class names
 
 Custom `className` can be used to provide a specific CSS class name that will be added to all cells in given column.
+You can also provide a `getCellProps` to customise class names for specific cells. More on this in [`useTable - cell properties`](https://react-table.tanstack.com/docs/api/useTable#cell-properties).
 
 ```js
+getCellProps={({ value, column }) => ({
+  className: `table__cell--${column.id} ${value ===  "1 minute" ? "p-heading--5" : ""}`,
+})}
 columns = {
   Header: "Hidden on mobile",
   accessor: "example",
@@ -67,6 +71,9 @@ columns = {
 <Preview>
   <Story name="Default">
     <ModularTable
+      getCellProps={({ value }) => ({
+        className: value ===  "1 minute" ? "p-heading--5" : "",
+      })}
       columns={React.useMemo(
         () => [
           {

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -96,3 +96,21 @@ it("renders extra props", () => {
 
   expect(screen.getByTestId("testID")).toBeInTheDocument();
 });
+
+it("allows setting custom aria-label for specific cells", async () => {
+  render(
+    <ModularTable
+      columns={columns}
+      data={data}
+      footer="This is a footer"
+      getCellProps={({ value }) => ({
+        "aria-label":
+          value === "Waiting" ? "This is a cell with custom label" : undefined,
+      })}
+    />
+  );
+
+  expect(
+    screen.getByRole("cell", { name: "This is a cell with custom label" })
+  ).toBeInTheDocument();
+});

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -4,10 +4,10 @@ import React from "react";
 import ModularTable from "./ModularTable";
 
 const columns = [
-  { accessor: "status", Header: "Status" },
-  { accessor: "cores", Header: "Cores", className: "u-align--right" },
-  { accessor: "ram", Header: "RAM", className: "u-align--right" },
-  { accessor: "disks", Header: "Disks", className: "u-align--right" },
+  { accessor: "status" as const, Header: "Status" },
+  { accessor: "cores" as const, Header: "Cores", className: "u-align--right" },
+  { accessor: "ram" as const, Header: "RAM", className: "u-align--right" },
+  { accessor: "disks" as const, Header: "Disks", className: "u-align--right" },
 ];
 const data = [
   {
@@ -97,12 +97,11 @@ it("renders extra props", () => {
   expect(screen.getByTestId("testID")).toBeInTheDocument();
 });
 
-it("allows setting custom aria-label for specific cells", async () => {
+it("allows setting custom aria-label for specific cells based on their value", async () => {
   render(
     <ModularTable
       columns={columns}
       data={data}
-      footer="This is a footer"
       getCellProps={({ value }) => ({
         "aria-label":
           value === "Waiting" ? "This is a cell with custom label" : undefined,
@@ -112,5 +111,43 @@ it("allows setting custom aria-label for specific cells", async () => {
 
   expect(
     screen.getByRole("cell", { name: "This is a cell with custom label" })
+  ).toBeInTheDocument();
+});
+
+it("allows setting custom attributes for cells in specific columns", async () => {
+  render(
+    <ModularTable
+      columns={columns}
+      data={data}
+      getCellProps={({ column }) => ({
+        role: column.id === "status" ? "rowheader" : undefined,
+      })}
+    />
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  const rowItems = within(tableBody).getAllByRole("row");
+
+  rowItems.forEach((row, index) => {
+    const rowheader = within(row).getByRole("rowheader");
+    expect(rowheader.textContent).toEqual(`${data[index].status}`);
+  });
+});
+
+it("allows setting custom attributes for specific rows", async () => {
+  render(
+    <ModularTable
+      columns={columns}
+      data={data}
+      getRowProps={(row) => ({
+        "aria-label":
+          row.values.status === "Idle" ? "Custom idle row label" : undefined,
+      })}
+    />
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  expect(
+    within(tableBody).getByRole("row", {
+      name: "Custom idle row label",
+    })
   ).toBeInTheDocument();
 });

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, HTMLProps } from "react";
 import { Cell, Row, useTable } from "react-table";
-import type { Column, TablePropGetter, UseTableOptions } from "react-table";
+import type { Column, UseTableOptions } from "react-table";
 import { PropsWithSpread } from "types";
 import Table from "../Table";
 import TableRow from "../TableRow";
@@ -35,17 +35,15 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
   HTMLProps<HTMLTableElement>
 >;
 
-const defaultPropGetter = () => ({});
-
 function ModularTable<D extends Record<string, unknown>>({
   data,
   columns,
   emptyMsg,
   footer,
-  getHeaderProps = defaultPropGetter,
-  getColumnProps = defaultPropGetter,
-  getRowProps = defaultPropGetter,
-  getCellProps = defaultPropGetter,
+  getHeaderProps,
+  getColumnProps,
+  getRowProps,
+  getCellProps,
   getRowId,
   ...props
 }: Props<D>): JSX.Element {
@@ -70,8 +68,8 @@ function ModularTable<D extends Record<string, unknown>>({
                       ? "p-table__cell--icon-placeholder"
                       : "",
                   },
-                  getColumnProps(column),
-                  getHeaderProps(column),
+                  getColumnProps?.(column) || {},
+                  getHeaderProps?.(column) || {},
                 ])}
               >
                 {column.render("Header")}
@@ -80,14 +78,14 @@ function ModularTable<D extends Record<string, unknown>>({
           </TableRow>
         ))}
       </thead>
-      <tbody {...getTableBodyProps()}>
+      <tbody {...getTableBodyProps?.()}>
         {rows.map((row) => {
           // This function is responsible for lazily preparing a row for rendering.
           // Any row that you intend to render in your table needs to be passed to this function before every render.
           // see: https://react-table.tanstack.com/docs/api/useTable#instance-properties
           prepareRow(row);
           return (
-            <TableRow {...row.getRowProps(getRowProps(row))}>
+            <TableRow {...row.getRowProps(getRowProps?.(row))}>
               {row.cells.map((cell) => {
                 const hasColumnIcon = cell.column.getCellIcon;
                 const iconName =
@@ -104,8 +102,8 @@ function ModularTable<D extends Record<string, unknown>>({
                           ? "p-table__cell--icon-placeholder"
                           : "",
                       },
-                      getColumnProps(cell.column),
-                      getCellProps(cell),
+                      getColumnProps?.(cell.column) || {},
+                      getCellProps?.(cell) || {},
                     ])}
                   >
                     {iconName && <Icon name={iconName} />}

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,6 +1,12 @@
 import React, { ReactNode, HTMLProps } from "react";
-import { Cell, Row, useTable } from "react-table";
-import type { Column, UseTableOptions } from "react-table";
+import { useTable } from "react-table";
+import type {
+  Column,
+  UseTableOptions,
+  Cell,
+  Row,
+  HeaderGroup,
+} from "react-table";
 import { PropsWithSpread } from "types";
 import Table from "../Table";
 import TableRow from "../TableRow";
@@ -26,10 +32,11 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
      * Optional extra row to display underneath the main table content.
      */
     footer?: ReactNode;
-    getHeaderProps?: (column: Column<D>) => Record<string, unknown>;
-    getColumnProps?: (column: Column<D>) => Record<string, unknown>;
-    getRowProps?: (row: Row<D>) => Record<string, unknown>;
-    getCellProps?: (cell: Cell<D>) => Record<string, unknown>;
+    getHeaderProps?: (
+      header: HeaderGroup<D>
+    ) => Partial<HTMLProps<HTMLTableHeaderCellElement>>;
+    getRowProps?: (row: Row<D>) => Partial<HTMLProps<HTMLTableRowElement>>;
+    getCellProps?: (cell: Cell<D>) => Partial<HTMLProps<HTMLTableCellElement>>;
     getRowId?: UseTableOptions<D>["getRowId"];
   },
   HTMLProps<HTMLTableElement>
@@ -41,7 +48,6 @@ function ModularTable<D extends Record<string, unknown>>({
   emptyMsg,
   footer,
   getHeaderProps,
-  getColumnProps,
   getRowProps,
   getCellProps,
   getRowId,
@@ -68,9 +74,8 @@ function ModularTable<D extends Record<string, unknown>>({
                       ? "p-table__cell--icon-placeholder"
                       : "",
                   },
-                  getColumnProps?.(column) || {},
-                  getHeaderProps?.(column) || {},
                 ])}
+                {...getHeaderProps?.(column)}
               >
                 {column.render("Header")}
               </TableHeader>
@@ -78,14 +83,14 @@ function ModularTable<D extends Record<string, unknown>>({
           </TableRow>
         ))}
       </thead>
-      <tbody {...getTableBodyProps?.()}>
+      <tbody {...getTableBodyProps()}>
         {rows.map((row) => {
           // This function is responsible for lazily preparing a row for rendering.
           // Any row that you intend to render in your table needs to be passed to this function before every render.
           // see: https://react-table.tanstack.com/docs/api/useTable#instance-properties
           prepareRow(row);
           return (
-            <TableRow {...row.getRowProps(getRowProps?.(row))}>
+            <TableRow {...row.getRowProps()} {...getRowProps?.(row)}>
               {row.cells.map((cell) => {
                 const hasColumnIcon = cell.column.getCellIcon;
                 const iconName =
@@ -102,9 +107,8 @@ function ModularTable<D extends Record<string, unknown>>({
                           ? "p-table__cell--icon-placeholder"
                           : "",
                       },
-                      getColumnProps?.(cell.column) || {},
-                      getCellProps?.(cell) || {},
                     ])}
+                    {...getCellProps?.(cell)}
                   >
                     {iconName && <Icon name={iconName} />}
                     {cell.render("Cell")}

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -37,12 +37,21 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
      * Optional extra row to display underneath the main table content.
      */
     footer?: ReactNode;
+    /**
+     * This function is used to resolve any props needed for a particular column's header cell.
+     */
     getHeaderProps?: (
       header: HeaderGroup<D>
     ) => Partial<TableHeaderProps & HTMLProps<HTMLTableHeaderCellElement>>;
+    /**
+     * This function is used to resolve any props needed for a particular row.
+     */
     getRowProps?: (
       row: Row<D>
     ) => Partial<TableRowProps & HTMLProps<HTMLTableRowElement>>;
+    /**
+     * This function is used to resolve any props needed for a particular cell.
+     */
     getCellProps?: (
       cell: Cell<D>
     ) => Partial<TableCellProps & HTMLProps<HTMLTableCellElement>>;

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode, HTMLProps } from "react";
-import { useTable } from "react-table";
+import {
+  TableCellProps,
+  TableHeaderProps,
+  TableRowProps,
+  useTable,
+} from "react-table";
 import type {
   Column,
   UseTableOptions,
@@ -34,9 +39,13 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
     footer?: ReactNode;
     getHeaderProps?: (
       header: HeaderGroup<D>
-    ) => Partial<HTMLProps<HTMLTableHeaderCellElement>>;
-    getRowProps?: (row: Row<D>) => Partial<HTMLProps<HTMLTableRowElement>>;
-    getCellProps?: (cell: Cell<D>) => Partial<HTMLProps<HTMLTableCellElement>>;
+    ) => Partial<TableHeaderProps & HTMLProps<HTMLTableHeaderCellElement>>;
+    getRowProps?: (
+      row: Row<D>
+    ) => Partial<TableRowProps & HTMLProps<HTMLTableRowElement>>;
+    getCellProps?: (
+      cell: Cell<D>
+    ) => Partial<TableCellProps & HTMLProps<HTMLTableCellElement>>;
     getRowId?: UseTableOptions<D>["getRowId"];
   },
   HTMLProps<HTMLTableElement>
@@ -74,8 +83,8 @@ function ModularTable<D extends Record<string, unknown>>({
                       ? "p-table__cell--icon-placeholder"
                       : "",
                   },
+                  { ...getHeaderProps?.(column) },
                 ])}
-                {...getHeaderProps?.(column)}
               >
                 {column.render("Header")}
               </TableHeader>
@@ -90,7 +99,7 @@ function ModularTable<D extends Record<string, unknown>>({
           // see: https://react-table.tanstack.com/docs/api/useTable#instance-properties
           prepareRow(row);
           return (
-            <TableRow {...row.getRowProps()} {...getRowProps?.(row)}>
+            <TableRow {...row.getRowProps(getRowProps?.(row))}>
               {row.cells.map((cell) => {
                 const hasColumnIcon = cell.column.getCellIcon;
                 const iconName =
@@ -107,8 +116,8 @@ function ModularTable<D extends Record<string, unknown>>({
                           ? "p-table__cell--icon-placeholder"
                           : "",
                       },
+                      { ...getCellProps?.(cell) },
                     ])}
-                    {...getCellProps?.(cell)}
                   >
                     {iconName && <Icon name={iconName} />}
                     {cell.render("Cell")}


### PR DESCRIPTION
## Done

- Allow customisation of specific headers, rows and cells
  - made possible with: `getHeaderProps`, `getRowProps` and `getCellProps` which resolve additional custom props for specific elements
- **[breaking change]** improve type safety (accessors)
Previously TypeScript would not complain about an invalid accessor string value. Now it expects not just a string, but a correct value for column accessors.
  - before: `{ accessor: "disks", Header: "Disks",`
  - after `{ accessor: "status" as const, Header: "Status" }`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/761
