### PR TITLE
Add missing props spreading for Chip, CodeSnippet, ModularTable and SearchBox

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -59,6 +59,7 @@ const Chip = ({
   selected,
   subString = "",
   value,
+  ...props
 }: Props): JSX.Element => {
   // When user tabs over chip and presses Enter or Space key, chip will trigger
   // click functionality
@@ -92,9 +93,9 @@ const Chip = ({
 
   if (onDismiss) {
     return (
-      <span className={chipClassName} aria-pressed={selected}>
+      <span className={chipClassName} aria-pressed={selected} {...props}>
         {chipContent}
-        <button className="p-chip__dismiss" onClick={() => onDismiss()}>
+        <button className="p-chip__dismiss" onClick={onDismiss}>
           <i className="p-icon--close">Dismiss</i>
         </button>
       </span>
@@ -106,6 +107,7 @@ const Chip = ({
         aria-pressed={selected}
         onClick={onClick}
         onKeyDown={(e) => onKeyDown(e)}
+        {...props}
       >
         {chipContent}
       </button>

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -17,7 +17,11 @@ export type Props = {
   blocks: CodeSnippetBlockProps[];
 };
 
-export default function CodeSnippet({ className, blocks }: Props): JSX.Element {
+export default function CodeSnippet({
+  className,
+  blocks,
+  ...props
+}: Props): JSX.Element {
   return (
     <div
       className={classNames(
@@ -25,11 +29,12 @@ export default function CodeSnippet({ className, blocks }: Props): JSX.Element {
         { "is-bordered": blocks.some((block) => block.content) },
         className
       )}
+      {...props}
     >
-      {blocks.map((props, i) => (
+      {blocks.map((blockProps, i) => (
         <CodeSnippetBlock
           key={`code-snippet-block-${i}`}
-          {...props}
+          {...blockProps}
         ></CodeSnippetBlock>
       ))}
     </div>

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -32,6 +32,7 @@ function ModularTable({
   columns,
   emptyMsg,
   footer,
+  ...props
 }: Props<Record<string, unknown>>): JSX.Element {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable({ columns, data });
@@ -39,7 +40,7 @@ function ModularTable({
   const showEmpty: boolean = emptyMsg && (!rows || rows.length === 0);
 
   return (
-    <Table {...getTableProps()}>
+    <Table {...getTableProps()} {...props}>
       <thead>
         {headerGroups.map((headerGroup) => (
           <TableRow {...headerGroup.getHeaderGroupProps()}>

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -49,6 +49,7 @@ const SearchBox = ({
   onSearch,
   placeholder = "Search",
   value,
+  ...props
 }: Props): JSX.Element => {
   const input = React.createRef<HTMLInputElement | null>();
   const resetInput = () => {
@@ -79,6 +80,7 @@ const SearchBox = ({
         type="search"
         defaultValue={externallyControlled ? undefined : value}
         value={externallyControlled ? value : undefined}
+        {...props}
       />
       {value && (
         <button


### PR DESCRIPTION


## Done

- Update the Chip, CodeSnipper, ModularTable and Searchbox components to accept extra props

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Not exactly sure. I edited the stories locally to pass extra props to the components and checked they were indeed passed

## Fixes

Fixes #722
