### PR TITLE
Add error and help aria labels to form fields

### DIFF
--- a/src/__mocks__/nanoid.ts
+++ b/src/__mocks__/nanoid.ts
@@ -1,0 +1,10 @@
+let id = 0;
+
+beforeEach(() => {
+  id = 0;
+});
+
+export const nanoid = (): string => {
+  id++;
+  return `mock-nanoid-${id}`;
+};

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,9 +1,18 @@
 import { mount, shallow } from "enzyme";
 import React from "react";
+import * as nanoid from "nanoid";
 
 import Accordion from "./Accordion";
 
 describe("Accordion", () => {
+  beforeEach(() => {
+    jest.spyOn(nanoid, "nanoid").mockReturnValue("mocked-nanoid");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("renders", () => {
     const wrapper = shallow(
       <Accordion
@@ -63,7 +72,7 @@ describe("Accordion", () => {
     const title = wrapper.find(".p-accordion__tab").at(0);
     title.simulate("click");
     expect(onExpandedChange).toHaveBeenCalledWith(
-      "mock-nanoid-1",
+      "mocked-nanoid",
       "Advanced topics"
     );
     // Clicking the title again should close the accordion section.

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,7 +1,6 @@
 import { mount, shallow } from "enzyme";
 import React from "react";
 
-import { MOCK_UUID } from "../../setupTests";
 import Accordion from "./Accordion";
 
 describe("Accordion", () => {
@@ -63,7 +62,10 @@ describe("Accordion", () => {
     );
     const title = wrapper.find(".p-accordion__tab").at(0);
     title.simulate("click");
-    expect(onExpandedChange).toHaveBeenCalledWith(MOCK_UUID, "Advanced topics");
+    expect(onExpandedChange).toHaveBeenCalledWith(
+      "mock-nanoid-1",
+      "Advanced topics"
+    );
     // Clicking the title again should close the accordion section.
     title.simulate("click");
     expect(onExpandedChange).toHaveBeenCalledWith(null, null);

--- a/src/components/AccordionSection/AccordionSection.test.tsx
+++ b/src/components/AccordionSection/AccordionSection.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import React from "react";
 
-import { MOCK_UUID } from "../../setupTests";
 import AccordionSection from "./AccordionSection";
 
 describe("AccordionSection ", () => {
@@ -50,12 +49,12 @@ describe("AccordionSection ", () => {
     );
     wrapper.find(".p-accordion__tab").at(0).simulate("click");
 
-    expect(onTitleClick.mock.calls[0]).toEqual([true, MOCK_UUID]);
+    expect(onTitleClick.mock.calls[0]).toEqual([true, "mock-nanoid-1"]);
     wrapper.setProps({ expanded });
     // Clicking the title again should close the accordion section.
     wrapper.find(".p-accordion__tab").at(0).simulate("click");
 
-    expect(onTitleClick.mock.calls[1]).toEqual([false, MOCK_UUID]);
+    expect(onTitleClick.mock.calls[1]).toEqual([false, "mock-nanoid-1"]);
   });
 
   it("can use a key for expanded state", () => {

--- a/src/components/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/components/AccordionSection/__snapshots__/AccordionSection.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`AccordionSection  renders 1`] = `
     role="heading"
   >
     <button
-      aria-controls="#Uakgb_J5m9g-0JDMbcJqLJ"
+      aria-controls="#mock-nanoid-1"
       aria-expanded="false"
       className="p-accordion__tab"
       onClick={[Function]}
@@ -22,9 +22,9 @@ exports[`AccordionSection  renders 1`] = `
   </div>
   <section
     aria-hidden="true"
-    aria-labelledby="Uakgb_J5m9g-0JDMbcJqLJ"
+    aria-labelledby="mock-nanoid-1"
     className="p-accordion__panel"
-    id="Uakgb_J5m9g-0JDMbcJqLJ"
+    id="mock-nanoid-1"
     role="tabpanel"
   >
     <span>
@@ -44,7 +44,7 @@ exports[`AccordionSection  renders headings for titles 1`] = `
     role={null}
   >
     <button
-      aria-controls="#Uakgb_J5m9g-0JDMbcJqLJ"
+      aria-controls="#mock-nanoid-1"
       aria-expanded="false"
       className="p-accordion__tab"
       onClick={[Function]}
@@ -56,9 +56,9 @@ exports[`AccordionSection  renders headings for titles 1`] = `
   </h4>
   <section
     aria-hidden="true"
-    aria-labelledby="Uakgb_J5m9g-0JDMbcJqLJ"
+    aria-labelledby="mock-nanoid-1"
     className="p-accordion__panel"
-    id="Uakgb_J5m9g-0JDMbcJqLJ"
+    id="mock-nanoid-1"
     role="tabpanel"
   >
     <span>

--- a/src/components/Field/Field.test.tsx
+++ b/src/components/Field/Field.test.tsx
@@ -22,10 +22,12 @@ describe("Field ", () => {
   });
 
   it("can display a caution message", () => {
-    const wrapper = shallow(<Field caution="Are you sure?" />);
+    const wrapper = shallow(
+      <Field caution="Are you sure?" validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Caution"}:</strong> {"Are you sure?"}
       </p>
     );
@@ -33,10 +35,12 @@ describe("Field ", () => {
   });
 
   it("can display a caution node", () => {
-    const wrapper = shallow(<Field caution={<span>Are you sure?</span>} />);
+    const wrapper = shallow(
+      <Field caution={<span>Are you sure?</span>} validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Caution"}:</strong> <span>Are you sure?</span>
       </p>
     );
@@ -44,10 +48,12 @@ describe("Field ", () => {
   });
 
   it("can display an error message", () => {
-    const wrapper = shallow(<Field error="You can't do that" />);
+    const wrapper = shallow(
+      <Field error="You can't do that" validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Error"}:</strong> {"You can't do that"}
       </p>
     );
@@ -55,10 +61,12 @@ describe("Field ", () => {
   });
 
   it("can display an error node", () => {
-    const wrapper = shallow(<Field error={<span>You can't do that</span>} />);
+    const wrapper = shallow(
+      <Field error={<span>You can't do that</span>} validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Error"}:</strong> <span>You can't do that</span>
       </p>
     );
@@ -66,10 +74,12 @@ describe("Field ", () => {
   });
 
   it("can display a success message", () => {
-    const wrapper = shallow(<Field success="You did it!" />);
+    const wrapper = shallow(
+      <Field success="You did it!" validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Success"}:</strong> {"You did it!"}
       </p>
     );
@@ -77,10 +87,12 @@ describe("Field ", () => {
   });
 
   it("can display a success node", () => {
-    const wrapper = shallow(<Field success={<span>You did it!</span>} />);
+    const wrapper = shallow(
+      <Field success={<span>You did it!</span>} validationId="id-1" />
+    );
     compareJSX(
       wrapper.find(".p-form-validation__message"),
-      <p className="p-form-validation__message">
+      <p className="p-form-validation__message" id="id-1">
         <strong>{"Success"}:</strong> <span>You did it!</span>
       </p>
     );
@@ -96,11 +108,11 @@ describe("Field ", () => {
 
   it("can display a help node", () => {
     const wrapper = shallow(
-      <Field help={<span>This is how you do it</span>} />
+      <Field help={<span>This is how you do it</span>} helpId="id-1" />
     );
     compareJSX(
       wrapper.find(".p-form-help-text"),
-      <p className="p-form-help-text">
+      <p className="p-form-help-text" id="id-1">
         <span>This is how you do it</span>
       </p>
     );

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -36,6 +36,10 @@ export type Props = {
    */
   help?: ReactNode;
   /**
+   * An id to give to the help element.
+   */
+  helpId?: string;
+  /**
    * Whether the component is wrapping a select element.
    */
   isSelect?: boolean;
@@ -63,15 +67,24 @@ export type Props = {
    * The content for success validation.
    */
   success?: ReactNode;
+  /**
+   * An id to give to the caution, error or success element.
+   */
+  validationId?: string;
 };
 
-const generateHelp = (help: Props["help"]) =>
-  help && <p className="p-form-help-text">{help}</p>;
+const generateHelp = (help: Props["help"], helpId: Props["helpId"]) =>
+  help && (
+    <p className="p-form-help-text" id={helpId}>
+      {help}
+    </p>
+  );
 
 const generateError = (
   error: Props["error"],
   caution: Props["caution"],
-  success: Props["success"]
+  success: Props["success"],
+  validationId: Props["validationId"]
 ) => {
   if (!error && !caution && !success) {
     return null;
@@ -79,7 +92,7 @@ const generateError = (
   const messageType =
     (error && "Error") || (caution && "Caution") || (success && "Success");
   return (
-    <p className="p-form-validation__message">
+    <p className="p-form-validation__message" id={validationId}>
       <strong>{messageType}:</strong> {error || caution || success}
     </p>
   );
@@ -114,7 +127,9 @@ const generateContent = (
   help: Props["help"],
   error: Props["error"],
   caution: Props["caution"],
-  success: Props["success"]
+  success: Props["success"],
+  validationId: string,
+  helpId: string
 ) => (
   <div className="p-form__control u-clearfix">
     {isSelect ? (
@@ -123,8 +138,8 @@ const generateContent = (
       children
     )}
     {!labelFirst && labelNode}
-    {generateHelp(help)}
-    {generateError(error, caution, success)}
+    {generateHelp(help, helpId)}
+    {generateError(error, caution, success, validationId)}
   </div>
 );
 
@@ -135,6 +150,7 @@ const Field = ({
   error,
   forId,
   help,
+  helpId,
   isSelect,
   label,
   labelClassName,
@@ -142,6 +158,7 @@ const Field = ({
   required,
   stacked,
   success,
+  validationId,
 }: Props): JSX.Element => {
   const labelNode = generateLabel(
     forId,
@@ -158,7 +175,9 @@ const Field = ({
     help,
     error,
     caution,
-    success
+    success,
+    validationId,
+    helpId
   );
   return (
     <div

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -107,7 +107,6 @@ Form controls have global styling defined at the HTML element level. Labels and 
         type="text"
         id="address-inline22"
         aria-invalid="true"
-        aria-describedby="input-error-message-inline"
         label="Email address"
         error="Please enter a valid email address."
       />

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,9 +1,10 @@
+import { render, screen } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Input from "./Input";
 
-describe("Input ", () => {
+describe("Input", () => {
   it("renders", () => {
     const wrapper = shallow(<Input type="text" id="test-id" />);
     expect(wrapper).toMatchSnapshot();
@@ -31,6 +32,7 @@ describe("Input ", () => {
     document.body.appendChild(container);
     const wrapper = mount(<Input takeFocus />, { attachTo: container });
     expect(wrapper.find("input").getDOMNode()).toBe(document.activeElement);
+    document.body.removeChild(container);
   });
 
   it("sets aria-invalid to false when there is no error", () => {
@@ -74,5 +76,40 @@ describe("Input ", () => {
     expect(
       wrapper.find("label").prop("className").includes("label-class-name")
     ).toBe(true);
+  });
+});
+
+describe("Input RTL", () => {
+  it("can display an error for a text input", async () => {
+    render(<Input error="Uh oh!" type="text" />);
+    expect(screen.getByRole("textbox")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display an error for a radiobutton", async () => {
+    render(<Input error="Uh oh!" type="radio" />);
+    expect(screen.getByRole("radio")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display an error for a checkbox", async () => {
+    render(<Input error="Uh oh!" type="checkbox" />);
+    expect(screen.getByRole("checkbox")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display help for a text input", async () => {
+    const help = "Save me!";
+    render(<Input help={help} type="text" />);
+    expect(screen.getByRole("textbox")).toHaveAccessibleDescription(help);
+  });
+
+  it("can display help for a radiobutton", async () => {
+    const help = "Save me!";
+    render(<Input help={help} type="radio" />);
+    expect(screen.getByRole("radio")).toHaveAccessibleDescription(help);
+  });
+
+  it("can display help for a checkbox", async () => {
+    const help = "Save me!";
+    render(<Input help={help} type="checkbox" />);
+    expect(screen.getByRole("checkbox")).toHaveAccessibleDescription(help);
   });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -7,6 +7,7 @@ import CheckboxInput from "../CheckboxInput";
 import RadioInput from "../RadioInput";
 
 import type { ClassName, PropsWithSpread } from "types";
+import { useId } from "hooks";
 
 /**
  * The props for the Input component.
@@ -83,6 +84,19 @@ const Input = ({
 }: Props): JSX.Element => {
   const inputRef = useRef(null);
   const fieldLabel = !["checkbox", "radio"].includes(type) ? label : "";
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
+
+  const commonProps = {
+    "aria-describedby": help ? helpId : null,
+    "aria-errormessage": hasError ? validationId : null,
+    "aria-invalid": hasError,
+    id: id,
+    label: label,
+    required: required,
+    ...inputProps,
+  };
 
   useEffect(() => {
     if (takeFocus) {
@@ -94,33 +108,26 @@ const Input = ({
   if (type === "checkbox") {
     input = (
       <CheckboxInput
-        id={id}
         label={label}
         labelClassName={labelClassName}
-        required={required}
-        {...inputProps}
+        {...commonProps}
       />
     );
   } else if (type === "radio") {
     input = (
       <RadioInput
-        id={id}
         label={label}
         labelClassName={labelClassName}
-        required={required}
-        {...inputProps}
+        {...commonProps}
       />
     );
   } else {
     input = (
       <input
         className={classNames("p-form-validation__input", className)}
-        id={id}
         ref={inputRef}
-        required={required}
         type={type}
-        aria-invalid={!!error}
-        {...inputProps}
+        {...commonProps}
       />
     );
   }
@@ -131,11 +138,13 @@ const Input = ({
       error={error}
       forId={id}
       help={help}
+      helpId={helpId}
       label={fieldLabel}
       labelClassName={labelClassName}
       required={required}
       stacked={stacked}
       success={success}
+      validationId={validationId}
     >
       {input}
     </Field>

--- a/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input  renders 1`] = `
+exports[`Input renders 1`] = `
 <Field
   forId="test-id"
+  helpId="mock-nanoid-2"
+  validationId="mock-nanoid-1"
 >
   <input
+    aria-describedby={null}
+    aria-errormessage={null}
     aria-invalid={false}
     className="p-form-validation__input"
     id="test-id"

--- a/src/components/PasswordToggle/PasswordToggle.test.tsx
+++ b/src/components/PasswordToggle/PasswordToggle.test.tsx
@@ -1,9 +1,10 @@
+import { render, screen } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import React from "react";
 
 import PasswordToggle from "./PasswordToggle";
 
-describe("PasswordToggle ", () => {
+describe("PasswordToggle", () => {
   it("can add additional classes", () => {
     const wrapper = shallow(
       <PasswordToggle id="test-id" className="extra-class" />
@@ -22,6 +23,7 @@ describe("PasswordToggle ", () => {
     });
     ref.current.focus();
     expect(wrapper.find("input").getDOMNode()).toBe(document.activeElement);
+    document.body.removeChild(container);
   });
 
   it("toggles the visibility of the password when the button is clicked", () => {
@@ -40,5 +42,20 @@ describe("PasswordToggle ", () => {
       />
     );
     expect(wrapper.find("input#test-id").prop("value")).toBe("My test value");
+  });
+});
+
+describe("PasswordToggle RTL", () => {
+  it("can display an error", async () => {
+    render(<PasswordToggle error="Uh oh!" id="test-id" label="password" />);
+    expect(screen.getByLabelText("password")).toHaveErrorMessage(
+      "Error: Uh oh!"
+    );
+  });
+
+  it("can display help", async () => {
+    const help = "Save me!";
+    render(<PasswordToggle help={help} id="test-id" label="password" />);
+    expect(screen.getByLabelText("password")).toHaveAccessibleDescription(help);
   });
 });

--- a/src/components/PasswordToggle/PasswordToggle.tsx
+++ b/src/components/PasswordToggle/PasswordToggle.tsx
@@ -7,6 +7,7 @@ import Field from "../Field";
 import Label from "../Label";
 
 import type { ClassName, PropsWithSpread } from "types";
+import { useId } from "hooks";
 
 /**
  * The props for the Password Toggle component.
@@ -80,6 +81,9 @@ const PasswordToggle = React.forwardRef<HTMLInputElement, Props>(
     ref
   ): JSX.Element => {
     const [isPassword, setIsPassword] = useState(true);
+    const validationId = useId();
+    const helpId = useId();
+    const hasError = !!error;
 
     const togglePassword = () => {
       if (isPassword) {
@@ -95,8 +99,10 @@ const PasswordToggle = React.forwardRef<HTMLInputElement, Props>(
         className={wrapperClassName}
         error={error}
         help={help}
+        helpId={helpId}
         required={required}
         success={success}
+        validationId={validationId}
       >
         <div className="p-form-password-toggle">
           <Label forId={id} required={required}>
@@ -118,11 +124,14 @@ const PasswordToggle = React.forwardRef<HTMLInputElement, Props>(
           </Button>
         </div>
         <input
+          aria-describedby={help ? helpId : null}
+          aria-errormessage={hasError ? validationId : null}
+          aria-invalid={hasError}
           className={classNames("p-form-validation__input", className)}
           id={id}
+          readOnly={readOnly}
           ref={ref}
           type={isPassword ? "password" : "text"}
-          readOnly={readOnly}
           {...inputProps}
         />
       </Field>

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,9 +1,10 @@
+import { render, screen } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import React from "react";
 
 import Select from "./Select";
 
-describe("Select ", () => {
+describe("Select", () => {
   it("renders", () => {
     const wrapper = shallow(
       <Select
@@ -43,10 +44,24 @@ describe("Select ", () => {
       attachTo: container,
     });
     expect(wrapper.find("select").getDOMNode()).toBe(document.activeElement);
+    document.body.removeChild(container);
   });
 
   it("can take null options", () => {
     const wrapper = shallow(<Select options={null} />);
     expect(wrapper.exists()).toBe(true);
+  });
+});
+
+describe("Select RTL", () => {
+  it("can display an error", async () => {
+    render(<Select error="Uh oh!" />);
+    expect(screen.getByRole("combobox")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display help", async () => {
+    const help = "Save me!";
+    render(<Select help={help} />);
+    expect(screen.getByRole("combobox")).toHaveAccessibleDescription(help);
   });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -10,6 +10,7 @@ import type {
 import Field from "../Field";
 
 import type { ClassName, PropsWithSpread } from "types";
+import { useId } from "hooks";
 
 type Option = OptionHTMLAttributes<HTMLOptionElement>;
 
@@ -103,6 +104,9 @@ const Select = ({
   ...selectProps
 }: Props): JSX.Element => {
   const selectRef = useRef(null);
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
 
   useEffect(() => {
     if (takeFocus) {
@@ -117,14 +121,19 @@ const Select = ({
       error={error}
       forId={id}
       help={help}
+      helpId={helpId}
       isSelect={true}
       label={label}
       labelClassName={labelClassName}
       required={required}
       stacked={stacked}
       success={success}
+      validationId={validationId}
     >
       <select
+        aria-describedby={help ? helpId : null}
+        aria-errormessage={hasError ? validationId : null}
+        aria-invalid={hasError}
         className={classNames("p-form-validation__input", className)}
         id={id}
         onChange={(evt) => onChange && onChange(evt)}

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -1,11 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select  renders 1`] = `
+exports[`Select renders 1`] = `
 <Field
   forId="test-id"
+  helpId="mock-nanoid-2"
   isSelect={true}
+  validationId="mock-nanoid-1"
 >
   <select
+    aria-describedby={null}
+    aria-errormessage={null}
+    aria-invalid={false}
     className="p-form-validation__input"
     id="test-id"
     onChange={[Function]}

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -1,3 +1,4 @@
+import { render, screen } from "@testing-library/react";
 import { shallow } from "enzyme";
 import React from "react";
 
@@ -22,5 +23,36 @@ describe("Slider", () => {
       <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
     );
     expect(wrapper.find("input[type='number']").exists()).toBe(true);
+  });
+});
+
+describe("Slider RTL", () => {
+  it("can display an error", async () => {
+    render(
+      <Slider
+        max={10}
+        min={0}
+        onChange={jest.fn()}
+        showInput={false}
+        value={5}
+        error="Uh oh!"
+      />
+    );
+    expect(screen.getByRole("slider")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display help", async () => {
+    const help = "Save me!";
+    render(
+      <Slider
+        max={10}
+        min={0}
+        onChange={jest.fn()}
+        showInput={false}
+        value={5}
+        help={help}
+      />
+    );
+    expect(screen.getByRole("slider")).toHaveAccessibleDescription(help);
   });
 });

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -4,6 +4,7 @@ import type { ChangeEventHandler, HTMLProps, ReactNode } from "react";
 import Field from "../Field";
 
 import type { PropsWithSpread } from "types";
+import { useId } from "hooks";
 
 export const FILLED_COLOR = "#0066CC";
 export const EMPTY_COLOR = "#D9D9D9";
@@ -77,6 +78,9 @@ export const Slider = ({
   showInput = false,
   ...inputProps
 }: Props): JSX.Element => {
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
   let style = {};
   if (navigator?.userAgent?.includes("AppleWebKit")) {
     // Range inputs on Webkit browsers don't have a built-in "filled" portion,
@@ -98,11 +102,16 @@ export const Slider = ({
       caution={caution}
       error={error}
       help={help}
+      helpId={helpId}
       label={label}
       required={required}
+      validationId={validationId}
     >
       <div className="p-slider__wrapper">
         <input
+          aria-describedby={help ? helpId : null}
+          aria-errormessage={hasError ? validationId : null}
+          aria-invalid={hasError}
           disabled={disabled}
           id={id}
           max={max}
@@ -115,6 +124,9 @@ export const Slider = ({
         />
         {showInput && (
           <input
+            aria-describedby={help ? helpId : null}
+            aria-errormessage={hasError ? validationId : null}
+            aria-invalid={hasError}
             className="p-slider__input"
             disabled={disabled || inputDisabled}
             max={max}

--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -1,3 +1,4 @@
+import { render, screen } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import React from "react";
 
@@ -21,10 +22,24 @@ describe("Textarea ", () => {
     document.body.appendChild(container);
     const wrapper = mount(<Textarea takeFocus />, { attachTo: container });
     expect(wrapper.find("textarea").getDOMNode()).toBe(document.activeElement);
+    document.body.removeChild(container);
   });
 
   it("can accept input attributes", () => {
     const wrapper = shallow(<Textarea autoComplete="on" />);
     expect(wrapper.exists()).toBe(true);
+  });
+});
+
+describe("Textarea RTL", () => {
+  it("can display an error for a text input", async () => {
+    render(<Textarea error="Uh oh!" />);
+    expect(screen.getByRole("textbox")).toHaveErrorMessage("Error: Uh oh!");
+  });
+
+  it("can display help for a text input", async () => {
+    const help = "Save me!";
+    render(<Textarea help={help} />);
+    expect(screen.getByRole("textbox")).toHaveAccessibleDescription(help);
   });
 });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -5,6 +5,7 @@ import type { TextareaHTMLAttributes, ReactNode } from "react";
 import Field from "../Field";
 
 import type { ClassName, PropsWithSpread } from "types";
+import { useId } from "hooks";
 
 /**
  * The props for the Textarea component.
@@ -86,6 +87,9 @@ const Textarea = ({
   ...props
 }: Props): JSX.Element => {
   const textareaRef = useRef(null);
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
 
   useEffect(() => {
     if (takeFocus) {
@@ -100,13 +104,18 @@ const Textarea = ({
       error={error}
       forId={id}
       help={help}
+      helpId={helpId}
       label={label}
       labelClassName={labelClassName}
       required={required}
       stacked={stacked}
       success={success}
+      validationId={validationId}
     >
       <textarea
+        aria-describedby={help ? helpId : null}
+        aria-errormessage={hasError ? validationId : null}
+        aria-invalid={hasError}
         className={classNames("p-form-validation__input", className)}
         id={id}
         onKeyUp={(evt) => {

--- a/src/components/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/components/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -3,8 +3,13 @@
 exports[`Textarea  renders 1`] = `
 <Field
   forId="test-id"
+  helpId="mock-nanoid-2"
+  validationId="mock-nanoid-1"
 >
   <textarea
+    aria-describedby={null}
+    aria-errormessage={null}
+    aria-invalid={false}
     className="p-form-validation__input"
     id="test-id"
     onKeyUp={[Function]}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,7 +3,3 @@ import Enzyme from "enzyme";
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
 
 Enzyme.configure({ adapter: new Adapter() });
-
-export const MOCK_UUID = "Uakgb_J5m9g-0JDMbcJqLJ";
-
-jest.mock("nanoid", () => ({ nanoid: () => MOCK_UUID }));


### PR DESCRIPTION
## Done

- Added aria labels to associate errors and help text to the field (some links to these roles in the issue: https://github.com/canonical-web-and-design/react-components/issues/725).
- Improved nanoid mock to avoid conflicts.

## QA
N/A no visual changes.

## Fixes

Fixes: #725.
