### PR TITLE
fix: Spinner renders text twice

### DIFF
--- a/src/components/Spinner/Spinner.test.tsx
+++ b/src/components/Spinner/Spinner.test.tsx
@@ -24,6 +24,7 @@ describe("<Spinner />", () => {
     expect(
       component.find("i").first().hasClass("p-icon--spinner")
     ).toBeTruthy();
+    expect(component.find("i").first().text()).toContain("Loading");
   });
 
   it("renders text correctly if given text prop", () => {
@@ -31,7 +32,7 @@ describe("<Spinner />", () => {
     const component = shallow(<Spinner text={text} />);
 
     expect(component.find("span").first().text()).toContain(text);
-    expect(component.find("i").first().text()).toContain(text);
+    expect(component.find("i").first().text()).not.toContain(text);
   });
 
   it("renders Loading... for icon text if no text prop is provided", () => {

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -45,7 +45,7 @@ const Spinner = ({
         "is-light": isLight,
       })}
     >
-      {text ? text : "Loading"}
+      {text ? "" : "Loading"}
     </i>
     {text && (
       <>

--- a/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -22,9 +22,7 @@ exports[`<Spinner /> renders and matches the snapshot with text 1`] = `
 >
   <i
     className="p-icon--spinner u-animation--spin"
-  >
-    foo
-  </i>
+  />
    
   <span>
     foo


### PR DESCRIPTION
## Done

- fix: Spinner renders text twice
  - Now text in the icon will only be rendered if no alternative text supplied (and act as a visually hidden description that's accessible for screen readers)

More details in the related issue #729 

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes:
- #729 
- canonical-web-and-design/app-tribe/issues/762 
