### PR TITLE
refactor: remove ModularTable strict type

### DIFF
--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -4,10 +4,10 @@ import React from "react";
 import ModularTable from "./ModularTable";
 
 const columns = [
-  { accessor: "status" as const, Header: "Status" },
-  { accessor: "cores" as const, Header: "Cores", className: "u-align--right" },
-  { accessor: "ram" as const, Header: "RAM", className: "u-align--right" },
-  { accessor: "disks" as const, Header: "Disks", className: "u-align--right" },
+  { accessor: "status", Header: "Status" },
+  { accessor: "cores", Header: "Cores", className: "u-align--right" },
+  { accessor: "ram", Header: "RAM", className: "u-align--right" },
+  { accessor: "disks", Header: "Disks", className: "u-align--right" },
 ];
 const data = [
   {

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -60,7 +60,7 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
   HTMLProps<HTMLTableElement>
 >;
 
-function ModularTable<D extends Record<string, unknown>>({
+function ModularTable({
   data,
   columns,
   emptyMsg,
@@ -70,9 +70,13 @@ function ModularTable<D extends Record<string, unknown>>({
   getCellProps,
   getRowId,
   ...props
-}: Props<D>): JSX.Element {
+}: Props<Record<string, unknown>>): JSX.Element {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    useTable<D>({ columns, data, getRowId: getRowId || undefined });
+    useTable<Record<string, unknown>>({
+      columns,
+      data,
+      getRowId: getRowId || undefined,
+    });
 
   const showEmpty: boolean = !!emptyMsg && (!rows || rows.length === 0);
 


### PR DESCRIPTION
## Done

- refactor: remove ModularTable strict type https://github.com/canonical-web-and-design/react-components/pull/723/files#r828529359

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
