### PR TITLE
Improvements to the chip component.

### DIFF
--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -42,18 +42,6 @@ describe("Chip ", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call onClick when onDismiss clicked", () => {
-    const onDismiss = jest.fn();
-    const onClick = jest.fn();
-    const wrapper = mount(
-      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={onDismiss} />
-    );
-    const dismissButton = wrapper.find(".p-chip__dismiss");
-    dismissButton.simulate("click");
-    expect(onDismiss).toHaveBeenCalledTimes(1);
-    expect(onClick).not.toHaveBeenCalled();
-  });
-
   it("calls onKeyDown when key pressed", () => {
     const onClick = jest.fn();
     const wrapper = mount(<Chip lead="Owner" value="Bob" onClick={onClick} />);
@@ -63,29 +51,9 @@ describe("Chip ", () => {
     expect(onClick.mock.calls[0]).toEqual([{ lead: "Owner", value: "Bob" }]);
   });
 
-  it("calls onKeyDown when key pressed on a dismissable chip", () => {
-    const onClick = jest.fn();
-    const wrapper = mount(
-      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={jest.fn()} />
-    );
-    const chip = wrapper.find(".p-chip");
-    chip.simulate("keydown", { key: "Enter" });
-    expect(onClick).toHaveBeenCalledTimes(1);
-    expect(onClick.mock.calls[0]).toEqual([{ lead: "Owner", value: "Bob" }]);
-  });
-
   it("calls onClick when clicking on the chip", () => {
     const onClick = jest.fn();
     const wrapper = mount(<Chip lead="Owner" value="Bob" onClick={onClick} />);
-    wrapper.find(".p-chip").simulate("click");
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onClick when clicking on a dismissable chip", () => {
-    const onClick = jest.fn();
-    const wrapper = mount(
-      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={jest.fn()} />
-    );
     wrapper.find(".p-chip").simulate("click");
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -153,17 +121,6 @@ describe("Chip ", () => {
     const wrapper = mount(
       <form onSubmit={onSubmit}>
         <Chip lead="Owner" value="Bob" />
-      </form>
-    );
-    wrapper.find(".p-chip").simulate("click");
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("does not submit forms when clicking on a dismissible chip", () => {
-    const onSubmit = jest.fn();
-    const wrapper = mount(
-      <form onSubmit={onSubmit}>
-        <Chip lead="Owner" onDismiss={jest.fn()} value="Bob" />
       </form>
     );
     wrapper.find(".p-chip").simulate("click");

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -42,6 +42,18 @@ describe("Chip ", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("does not call onClick when onDismiss clicked", () => {
+    const onDismiss = jest.fn();
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={onDismiss} />
+    );
+    const dismissButton = wrapper.find(".p-chip__dismiss");
+    dismissButton.simulate("click");
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it("calls onKeyDown when key pressed", () => {
     const onClick = jest.fn();
     const wrapper = mount(<Chip lead="Owner" value="Bob" onClick={onClick} />);

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -51,6 +51,33 @@ describe("Chip ", () => {
     expect(onClick.mock.calls[0]).toEqual([{ lead: "Owner", value: "Bob" }]);
   });
 
+  it("calls onKeyDown when key pressed on a dismissable chip", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={jest.fn()} />
+    );
+    const chip = wrapper.find(".p-chip");
+    chip.simulate("keydown", { key: "Enter" });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0]).toEqual([{ lead: "Owner", value: "Bob" }]);
+  });
+
+  it("calls onClick when clicking on the chip", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(<Chip lead="Owner" value="Bob" onClick={onClick} />);
+    wrapper.find(".p-chip").simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClick when clicking on a dismissable chip", () => {
+    const onClick = jest.fn();
+    const wrapper = mount(
+      <Chip lead="Owner" value="Bob" onClick={onClick} onDismiss={jest.fn()} />
+    );
+    wrapper.find(".p-chip").simulate("click");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("renders positive chip", () => {
     const wrapper = shallow(<Chip appearance="positive" value="positive" />);
     expect(wrapper.prop("className").includes("p-chip--positive")).toBe(true);
@@ -74,6 +101,7 @@ describe("Chip ", () => {
       true
     );
   });
+
   it("renders extra props", () => {
     const wrapper = shallow(
       <Chip
@@ -87,5 +115,57 @@ describe("Chip ", () => {
     expect(
       wrapper.find(".p-chip--information").first().props()["data-testid"]
     ).toEqual("testID");
+  });
+
+  it("passes additional classes", () => {
+    const wrapper = shallow(
+      <Chip className="extra-extra" lead="Owner" value="Bob" />
+    );
+    expect(wrapper.prop("className")).toBe("p-chip extra-extra");
+  });
+
+  it("passes additional classes to a dismissable chip", () => {
+    const wrapper = shallow(
+      <Chip
+        className="extra-extra"
+        lead="Owner"
+        onDismiss={jest.fn()}
+        value="Bob"
+      />
+    );
+    expect(wrapper.prop("className")).toBe("p-chip extra-extra");
+  });
+
+  it("does not submit forms when clicking on the chip", () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(
+      <form onSubmit={onSubmit}>
+        <Chip lead="Owner" value="Bob" />
+      </form>
+    );
+    wrapper.find(".p-chip").simulate("click");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit forms when clicking on a dismissible chip", () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(
+      <form onSubmit={onSubmit}>
+        <Chip lead="Owner" onDismiss={jest.fn()} value="Bob" />
+      </form>
+    );
+    wrapper.find(".p-chip").simulate("click");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit forms when clicking on the dismiss button", () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(
+      <form onSubmit={onSubmit}>
+        <Chip lead="Owner" onDismiss={jest.fn()} value="Bob" />
+      </form>
+    );
+    wrapper.find(".p-chip__dismiss").simulate("click");
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -26,10 +26,7 @@ export type Props = PropsWithSpread<
      * Function for handling chip div click event.
      */
     onClick?: (
-      event:
-        | MouseEvent<HTMLButtonElement>
-        | MouseEvent<HTMLSpanElement>
-        | { lead: string; value: string }
+      event: MouseEvent<HTMLButtonElement> | { lead: string; value: string }
     ) => void;
     /**
      * Function for handling dismissing a chip.
@@ -69,7 +66,7 @@ const Chip = ({
 }: Props): JSX.Element => {
   // When user tabs over chip and presses Enter or Space key, chip will trigger
   // click functionality
-  const onKeyDown = <E,>(e: KeyboardEvent<E>) => {
+  const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     // The " " value is what is returned for the spacebar
     if (e.key === " " || e.key === "Enter") {
       if (typeof onClick === "function") {
@@ -100,31 +97,11 @@ const Chip = ({
     props.className
   );
 
-  const commonProps = {
-    ...props,
-    "aria-pressed": selected,
-    className: chipClassName,
-    onClick: onClick,
-  };
-
   if (onDismiss) {
     return (
-      <span
-        {...commonProps}
-        onKeyDown={(e) => onKeyDown<HTMLSpanElement>(e)}
-        role="button"
-        tabIndex={0}
-      >
+      <span {...props} className={chipClassName}>
         {chipContent}
-        <button
-          className="p-chip__dismiss"
-          onClick={(evt) => {
-            // Prevent the dismiss click from calling the chip onClick handler.
-            evt.stopPropagation();
-            onDismiss();
-          }}
-          type="button"
-        >
+        <button className="p-chip__dismiss" onClick={onDismiss} type="button">
           <i className="p-icon--close">Dismiss</i>
         </button>
       </span>
@@ -132,8 +109,11 @@ const Chip = ({
   } else {
     return (
       <button
-        {...commonProps}
-        onKeyDown={(e) => onKeyDown<HTMLButtonElement>(e)}
+        {...props}
+        aria-pressed={selected}
+        className={chipClassName}
+        onClick={onClick}
+        onKeyDown={(e) => onKeyDown(e)}
         type="button"
       >
         {chipContent}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -116,7 +116,15 @@ const Chip = ({
         tabIndex={0}
       >
         {chipContent}
-        <button className="p-chip__dismiss" onClick={onDismiss} type="button">
+        <button
+          className="p-chip__dismiss"
+          onClick={(evt) => {
+            // Prevent the dismiss click from calling the chip onClick handler.
+            evt.stopPropagation();
+            onDismiss();
+          }}
+          type="button"
+        >
           <i className="p-icon--close">Dismiss</i>
         </button>
       </span>

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -26,7 +26,10 @@ export type Props = PropsWithSpread<
      * Function for handling chip div click event.
      */
     onClick?: (
-      event: MouseEvent<HTMLButtonElement> | { lead: string; value: string }
+      event:
+        | MouseEvent<HTMLButtonElement>
+        | MouseEvent<HTMLSpanElement>
+        | { lead: string; value: string }
     ) => void;
     /**
      * Function for handling dismissing a chip.
@@ -50,7 +53,7 @@ export type Props = PropsWithSpread<
      */
     value: string;
   },
-  HTMLProps<HTMLSpanElement>
+  HTMLProps<HTMLButtonElement>
 >;
 
 const Chip = ({
@@ -66,7 +69,7 @@ const Chip = ({
 }: Props): JSX.Element => {
   // When user tabs over chip and presses Enter or Space key, chip will trigger
   // click functionality
-  const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+  const onKeyDown = <E,>(e: KeyboardEvent<E>) => {
     // The " " value is what is returned for the spacebar
     if (e.key === " " || e.key === "Enter") {
       if (typeof onClick === "function") {
@@ -89,16 +92,31 @@ const Chip = ({
     </>
   );
 
-  const chipClassName = classNames({
-    [`p-chip--${appearance}`]: !!appearance,
-    "p-chip": !appearance,
-  });
+  const chipClassName = classNames(
+    {
+      [`p-chip--${appearance}`]: !!appearance,
+      "p-chip": !appearance,
+    },
+    props.className
+  );
+
+  const commonProps = {
+    ...props,
+    "aria-pressed": selected,
+    className: chipClassName,
+    onClick: onClick,
+  };
 
   if (onDismiss) {
     return (
-      <span className={chipClassName} aria-pressed={selected} {...props}>
+      <span
+        {...commonProps}
+        onKeyDown={(e) => onKeyDown<HTMLSpanElement>(e)}
+        role="button"
+        tabIndex={0}
+      >
         {chipContent}
-        <button className="p-chip__dismiss" onClick={onDismiss}>
+        <button className="p-chip__dismiss" onClick={onDismiss} type="button">
           <i className="p-icon--close">Dismiss</i>
         </button>
       </span>
@@ -106,10 +124,9 @@ const Chip = ({
   } else {
     return (
       <button
-        className={chipClassName}
-        aria-pressed={selected}
-        onClick={onClick}
-        onKeyDown={(e) => onKeyDown(e)}
+        {...commonProps}
+        onKeyDown={(e) => onKeyDown<HTMLButtonElement>(e)}
+        type="button"
       >
         {chipContent}
       </button>

--- a/src/components/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/Chip/__snapshots__/Chip.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Chip  renders default chip 1`] = `
 <button
   className="p-chip"
   onKeyDown={[Function]}
+  type="button"
 >
   <span
     className="p-chip__value"
@@ -20,6 +21,7 @@ exports[`Chip  renders lead-value chip 1`] = `
 <button
   className="p-chip"
   onKeyDown={[Function]}
+  type="button"
 >
   <span
     className="p-chip__lead"


### PR DESCRIPTION
## Done

- Spread props on non-dismissible chips.
- Prevent form submissions when chips are inside forms.
- Prevent className spread wiping the "p-chip" classes.

## QA

N/A not really possible (I linked react-components to maas-ui and testing with my in-progress branch).

## Fixes

Fixes: #739.
Fixes: #738.
Fixes: #737.
