### PR TITLE
Add aria-current to Pagination Item

### DIFF
--- a/src/components/PaginationItem/PaginationItem.test.tsx
+++ b/src/components/PaginationItem/PaginationItem.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import PaginationItem from "./PaginationItem";
 
@@ -15,29 +15,20 @@ describe("<PaginationItem />", () => {
 
   // unit tests
   it("displays the page number", () => {
-    const { container } = render(
-      <PaginationItem number={1} onClick={jest.fn()} isActive />
-    );
+    render(<PaginationItem number={1} onClick={jest.fn()} isActive />);
 
-    expect(container.querySelector("button")).toHaveTextContent("1");
+    expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
   });
 
   it("sets isActive", () => {
-    const { container } = render(
-      <PaginationItem number={1} onClick={jest.fn()} isActive />
-    );
+    render(<PaginationItem number={1} onClick={jest.fn()} isActive />);
 
-    expect(container.querySelector("button")).toHaveClass("is-active");
+    expect(screen.getByRole("button")).toHaveClass("is-active");
   });
 
   it("sets aria-current when isActive is true", () => {
-    const { container } = render(
-      <PaginationItem number={1} onClick={jest.fn()} isActive />
-    );
+    render(<PaginationItem number={1} onClick={jest.fn()} isActive />);
 
-    expect(container.querySelector("button")).toHaveAttribute(
-      "aria-current",
-      "page"
-    );
+    expect(screen.getByRole("button", { current: "page" })).toBeInTheDocument();
   });
 });

--- a/src/components/PaginationItem/PaginationItem.test.tsx
+++ b/src/components/PaginationItem/PaginationItem.test.tsx
@@ -1,32 +1,43 @@
-import { shallow } from "enzyme";
 import React from "react";
+import { render } from "@testing-library/react";
 
 import PaginationItem from "./PaginationItem";
 
 describe("<PaginationItem />", () => {
   // snapshot tests
   it("renders and matches the snapshot", () => {
-    const component = shallow(
+    const { container } = render(
       <PaginationItem number={1} onClick={jest.fn()} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   // unit tests
   it("displays the page number", () => {
-    const component = shallow(
-      <PaginationItem number={1} onClick={jest.fn()} />
-    );
-
-    expect(component.find("button").text()).toEqual("1");
-  });
-
-  it("sets isActive", () => {
-    const component = shallow(
+    const { container } = render(
       <PaginationItem number={1} onClick={jest.fn()} isActive />
     );
 
-    expect(component.find("button").hasClass("is-active"));
+    expect(container.querySelector("button")).toHaveTextContent("1");
+  });
+
+  it("sets isActive", () => {
+    const { container } = render(
+      <PaginationItem number={1} onClick={jest.fn()} isActive />
+    );
+
+    expect(container.querySelector("button")).toHaveClass("is-active");
+  });
+
+  it("sets aria-current when isActive is true", () => {
+    const { container } = render(
+      <PaginationItem number={1} onClick={jest.fn()} isActive />
+    );
+
+    expect(container.querySelector("button")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
   });
 });

--- a/src/components/PaginationItem/PaginationItem.tsx
+++ b/src/components/PaginationItem/PaginationItem.tsx
@@ -28,6 +28,7 @@ const PaginationItem = ({
         "is-active": isActive,
       })}
       onClick={onClick}
+      aria-current={isActive ? "page" : "false"}
     >
       {number}
     </button>

--- a/src/components/PaginationItem/PaginationItem.tsx
+++ b/src/components/PaginationItem/PaginationItem.tsx
@@ -28,7 +28,7 @@ const PaginationItem = ({
         "is-active": isActive,
       })}
       onClick={onClick}
-      aria-current={isActive ? "page" : "false"}
+      aria-current={isActive ? "page" : undefined}
     >
       {number}
     </button>

--- a/src/components/PaginationItem/__snapshots__/PaginationItem.test.tsx.snap
+++ b/src/components/PaginationItem/__snapshots__/PaginationItem.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`<PaginationItem /> renders and matches the snapshot 1`] = `
     class="p-pagination__item"
   >
     <button
-      aria-current="false"
       class="p-pagination__link"
     >
       1

--- a/src/components/PaginationItem/__snapshots__/PaginationItem.test.tsx.snap
+++ b/src/components/PaginationItem/__snapshots__/PaginationItem.test.tsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PaginationItem /> renders and matches the snapshot 1`] = `
-<li
-  className="p-pagination__item"
->
-  <button
-    className="p-pagination__link"
-    onClick={[MockFunction]}
+<div>
+  <li
+    class="p-pagination__item"
   >
-    1
-  </button>
-</li>
+    <button
+      aria-current="false"
+      class="p-pagination__link"
+    >
+      1
+    </button>
+  </li>
+</div>
 `;


### PR DESCRIPTION
## Done

- Add `aria-current` to `Pagination Item` when it is active
- Add test for `aria-current`
- Update tests to use react testing library instead of jest 

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Click around and check nothing is broken
- Inspect the active button on the pagination docs, check `aria-current=page`

## Fixes

Fixes: #732
