### PR TITLE
fix: align input help text for checkbox & radio

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -44,6 +44,10 @@ export type Props = {
    */
   isSelect?: boolean;
   /**
+   * Whether the component is wrapping a checkbox or radio element.
+   */
+  isTickElement?: boolean;
+  /**
    * The label for the field.
    */
   label?: ReactNode;
@@ -73,12 +77,21 @@ export type Props = {
   validationId?: string;
 };
 
-const generateHelp = (help: Props["help"], helpId: Props["helpId"]) =>
-  help && (
-    <p className="p-form-help-text" id={helpId}>
+const generateHelpText = ({
+  help,
+  helpId,
+  isTickElement,
+}: Pick<Props, "help" | "helpId" | "isTickElement">) =>
+  help ? (
+    <p
+      className={classNames("p-form-help-text", {
+        "is-tick-element": isTickElement,
+      })}
+      id={helpId}
+    >
       {help}
     </p>
-  );
+  ) : null;
 
 const generateError = (
   error: Props["error"],
@@ -119,18 +132,23 @@ const generateLabel = (
   return labelNode;
 };
 
-const generateContent = (
-  isSelect: Props["isSelect"],
-  children: Props["children"],
-  labelFirst: Props["labelFirst"],
-  labelNode: JSX.Element | null,
-  help: Props["help"],
-  error: Props["error"],
-  caution: Props["caution"],
-  success: Props["success"],
-  validationId: string,
-  helpId: string
-) => (
+const generateContent = ({
+  isSelect,
+  children,
+  labelFirst,
+  labelNode,
+  help,
+  error,
+  caution,
+  success,
+  validationId,
+  helpId,
+  isTickElement,
+}: Partial<Props> & {
+  labelNode: JSX.Element | null;
+  validationId: string;
+  helpId: string;
+}) => (
   <div className="p-form__control u-clearfix">
     {isSelect ? (
       <div className="p-form-validation__select-wrapper">{children}</div>
@@ -138,7 +156,11 @@ const generateContent = (
       children
     )}
     {!labelFirst && labelNode}
-    {generateHelp(help, helpId)}
+    {generateHelpText({
+      helpId,
+      help,
+      isTickElement,
+    })}
     {generateError(error, caution, success, validationId)}
   </div>
 );
@@ -152,6 +174,7 @@ const Field = ({
   help,
   helpId,
   isSelect,
+  isTickElement,
   label,
   labelClassName,
   labelFirst = true,
@@ -167,8 +190,10 @@ const Field = ({
     labelClassName,
     stacked
   );
-  const content = generateContent(
+
+  const content = generateContent({
     isSelect,
+    isTickElement,
     children,
     labelFirst,
     labelNode,
@@ -177,8 +202,8 @@ const Field = ({
     caution,
     success,
     validationId,
-    helpId
-  );
+    helpId,
+  });
   return (
     <div
       className={classNames("p-form__group", "p-form-validation", className, {

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -66,6 +66,7 @@ An input field where the user can enter data, which can vary in many ways, depen
       id: "exampleTextInput2",
       placeholder: "example@canonical.com",
       label: "Email address",
+      help: "Additional description for the field",
     }}
   >
     {Template.bind({})}
@@ -161,7 +162,7 @@ An input field where the user can enter data, which can vary in many ways, depen
 <Canvas>
   <Story name="Checkbox">
     <Input type="checkbox" id="checkExample12" defaultChecked label="HTML" />
-    <Input type="checkbox" id="checkExample22" label="CSS" />
+    <Input type="checkbox" id="checkExample22" label="CSS" help="Cascading Style Sheets" />
     <Input
       type="checkbox"
       id="checkExample32"
@@ -182,6 +183,7 @@ An input field where the user can enter data, which can vary in many ways, depen
       id="Radio12"
       defaultValue="option1"
       defaultChecked
+      help="Ubuntu"
     />
     <Input
       label="Mac OS"

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -5,11 +5,6 @@ import React from "react";
 import Input from "./Input";
 
 describe("Input", () => {
-  it("renders", () => {
-    const wrapper = shallow(<Input type="text" id="test-id" />);
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it("can add additional classes", () => {
     const wrapper = shallow(<Input type="text" className="extra-class" />);
     const className = wrapper.find("input").prop("className");
@@ -80,6 +75,11 @@ describe("Input", () => {
 });
 
 describe("Input RTL", () => {
+  it("renders", () => {
+    const { container } = render(<Input type="text" id="test-id" />);
+    expect(container).toMatchSnapshot();
+  });
+
   it("can display an error for a text input", async () => {
     render(<Input error="Uh oh!" type="text" />);
     expect(screen.getByRole("textbox")).toHaveErrorMessage("Error: Uh oh!");

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -139,6 +139,7 @@ const Input = ({
       forId={id}
       help={help}
       helpId={helpId}
+      isTickElement={type === "checkbox" || type === "radio"}
       label={fieldLabel}
       labelClassName={labelClassName}
       required={required}

--- a/src/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.test.tsx.snap
@@ -1,18 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input renders 1`] = `
-<Field
-  forId="test-id"
-  helpId="mock-nanoid-2"
-  validationId="mock-nanoid-1"
->
-  <input
-    aria-describedby={null}
-    aria-errormessage={null}
-    aria-invalid={false}
-    className="p-form-validation__input"
-    id="test-id"
-    type="text"
-  />
-</Field>
+exports[`Input RTL renders 1`] = `
+<div>
+  <div
+    class="p-form__group p-form-validation"
+  >
+    <div
+      class="p-form__control u-clearfix"
+    >
+      <input
+        aria-invalid="false"
+        class="p-form-validation__input"
+        id="test-id"
+        type="text"
+      />
+    </div>
+  </div>
+</div>
 `;


### PR DESCRIPTION
## Done

- align input help text for checkbox & radio to match the spec https://vanillaframework.io/docs/base/forms#help-text
  - add help text examples to storybook
  - migrate Input snapshot test to testing-library
  - add `isTickElement` prop

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/161690734-a6e3caab-6605-4ab3-b650-5e2317905e43.png)

### After
![image](https://user-images.githubusercontent.com/7452681/161690748-5297a4a3-fa25-4d93-bfab-838eba7173da.png)

#### Additional storybook examples
![image](https://user-images.githubusercontent.com/7452681/161690806-17b2333d-2929-4f92-ac1e-2f6d87f36bc7.png)
![image](https://user-images.githubusercontent.com/7452681/161690819-36edce2c-569a-4ad5-9f10-e9c6166b897b.png)

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Verify that the help text is displayed correctly in different input types

## Fixes

Fixes: https://github.com/canonical-web-and-design/react-components/issues/748
