### PR TITLE
fix: tooltip accessibility

### DIFF
--- a/cypress/integration/tooltip.spec.js
+++ b/cypress/integration/tooltip.spec.js
@@ -1,0 +1,11 @@
+context("Tooltip", () => {
+  beforeEach(() => {
+    cy.visitPage("Tooltip");
+  });
+
+  it("clicking the child button element opens the tooltip", () => {
+    cy.findByRole("tooltip").should("not.exist");
+    cy.findByRole("button", { name: /Hover over me!/ }).click();
+    cy.findByRole("tooltip").should("exist");
+  });
+});

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -1,8 +1,19 @@
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
 import Button from "../Button";
-import Tooltip from "./Tooltip";
+import Tooltip, { position } from "./Tooltip";
 
-<Meta title="Tooltip" component={Tooltip} />
+<Meta
+  title="Tooltip"
+  component={Tooltip}
+  argTypes={{
+    position: {
+      control: {
+        type: "radio",
+      },
+      options: Object.values(position),
+    },
+  }}
+/>
 
 export const Template = (args) => {
   return (
@@ -31,7 +42,12 @@ An alternative use of tooltips is to provide information on a disabled actionabl
 ### Default
 
 <Canvas>
-  <Story name="Default" args={{ message: "Tooltip message to display." }}>
+  <Story
+    name="Default"
+    args={{
+      message: <>Tooltip <a href="#todo" target="_blank">Link1</a></>
+    }}
+  >
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,69 +1,129 @@
-import { mount, shallow } from "enzyme";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import merge from "deepmerge";
 import React from "react";
 
 import Tooltip, { adjustForWindow } from "./Tooltip";
 
-describe("<Tooltip />", () => {
-  const body = document.querySelector("body");
-  const app = document.createElement("div");
-  app.setAttribute("id", "app");
-  body.appendChild(app);
-
-  // snapshot tests
+describe("Tooltip", () => {
   it("renders and matches the snapshot", () => {
-    const component = shallow(<Tooltip message="text">Child</Tooltip>);
-    expect(component).toMatchSnapshot();
-  });
-
-  // unit tests
-  it("does not show tooltip message by default", () => {
-    const component = mount(<Tooltip message="text">Child</Tooltip>);
-    expect(component.exists("[data-testid='tooltip-portal']")).toEqual(false);
-  });
-
-  it("renders tooltip message when focused", () => {
-    const component = mount(<Tooltip message="text">Child</Tooltip>);
-    component.simulate("focus");
-    expect(component.find("[data-testid='tooltip-portal']").text()).toEqual(
-      "text"
-    );
-  });
-
-  it("can display elements inside the message", () => {
-    const component = mount(
-      <Tooltip message={<strong>message</strong>}>Child</Tooltip>
-    );
-    component.simulate("focus");
-    expect(
-      component.find("[data-testid='tooltip-portal'] strong").exists()
-    ).toBe(true);
-  });
-
-  it("gives the correct class name to the tooltip", () => {
-    const component = mount(
-      <Tooltip message="text" position="right">
-        Child
+    const { container } = render(
+      <Tooltip message="text">
+        <button>button text</button>
       </Tooltip>
     );
-    component.simulate("focus");
-    expect(component.exists(".p-tooltip--right")).toEqual(true);
+    expect(container).toMatchSnapshot();
   });
 
-  it("updates the tooltip to fit on the screen", () => {
-    const wrapper = mount(
+  it("focuses on the first focusable element within the tooltip on pressing tab ", () => {
+    render(
+      <Tooltip
+        message={
+          <>
+            Additional information <a href="canonical.com">Canonical</a>
+          </>
+        }
+      >
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+
+    userEvent.click(screen.getByRole("button", { name: /open the tooltip/i }));
+    userEvent.tab();
+
+    expect(screen.getByRole("link", { name: "Canonical" })).toHaveFocus();
+  });
+
+  it("adds a description to the wrapped element", () => {
+    render(
+      <Tooltip message="Additional description">
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+    expect(
+      screen.getByRole("button", { name: /open the tooltip/ })
+    ).toHaveAccessibleDescription("Additional description");
+  });
+
+  it("preserves click handlers for elements within the tooltip", () => {
+    const clickHandler = jest.fn();
+
+    render(
+      <Tooltip
+        message={
+          <>
+            Additional information{" "}
+            <a
+              href="canonical.com"
+              onClick={(e) => {
+                e.preventDefault();
+                clickHandler();
+              }}
+            >
+              Canonical
+            </a>
+          </>
+        }
+      >
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+
+    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByRole("link", { name: "Canonical" }));
+
+    expect(clickHandler).toHaveBeenCalled();
+  });
+
+  it("does not show tooltip message by default", () => {
+    render(<Tooltip message="text">Child</Tooltip>);
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass("u-off-screen");
+  });
+
+  it("renders tooltip message on focus", () => {
+    render(
+      <Tooltip message="text">
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass("u-off-screen");
+    userEvent.tab();
+    expect(screen.getByTestId("tooltip-portal")).not.toHaveClass(
+      "u-off-screen"
+    );
+  });
+
+  it("updates the tooltip to fit on the screen", async () => {
+    render(
       <Tooltip
         message="text that is too long to fit on the screen"
         position="right"
       >
-        Child
+        <button>Child</button>
       </Tooltip>
     );
     global.innerWidth = 20;
-    wrapper.simulate("mouseover");
-    expect(
-      wrapper.find("[data-testid='tooltip-portal']").prop("className")
-    ).toBe("p-tooltip--btm-left is-detached");
+    userEvent.hover(screen.getByRole("button", { name: "Child" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tooltip-portal")).toHaveClass(
+        "p-tooltip--btm-left"
+      )
+    );
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass("is-detached");
+  });
+
+  it("gives the correct class name to the tooltip", () => {
+    render(
+      <Tooltip message="text" position="right">
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass(
+      "p-tooltip--right"
+    );
   });
 
   describe("adjustForWindow", () => {

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,39 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tooltip - detached renders and matches the snapshot 1`] = `
-<div>
-  <span>
-    <span
-      style="display: inline-block;"
-    >
-      <button
-        aria-describedby="mock-nanoid-1"
-      >
-        button text
-      </button>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`Tooltip - regular renders and matches the snapshot 1`] = `
-<div>
-  <button
-    aria-describedby="mock-nanoid-1"
-    class="p-tooltip p-tooltip--top-left"
-  >
-    button text
-    <span
-      class="p-tooltip__message"
-      id="mock-nanoid-1"
-      role="tooltip"
-    >
-      text
-    </span>
-  </button>
-</div>
-`;
-
 exports[`Tooltip renders and matches the snapshot 1`] = `
 <div>
   <span>

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,22 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip /> renders and matches the snapshot 1`] = `
-<Fragment>
-  <span
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
-  >
+exports[`Tooltip - detached renders and matches the snapshot 1`] = `
+<div>
+  <span>
     <span
-      style={
-        Object {
-          "display": "inline-block",
-        }
-      }
+      style="display: inline-block;"
     >
-      Child
+      <button
+        aria-describedby="mock-nanoid-1"
+      >
+        button text
+      </button>
     </span>
   </span>
-</Fragment>
+</div>
+`;
+
+exports[`Tooltip - regular renders and matches the snapshot 1`] = `
+<div>
+  <button
+    aria-describedby="mock-nanoid-1"
+    class="p-tooltip p-tooltip--top-left"
+  >
+    button text
+    <span
+      class="p-tooltip__message"
+      id="mock-nanoid-1"
+      role="tooltip"
+    >
+      text
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Tooltip renders and matches the snapshot 1`] = `
+<div>
+  <span>
+    <span
+      style="display: inline-block;"
+    >
+      <button
+        aria-describedby="mock-nanoid-1"
+      >
+        button text
+      </button>
+    </span>
+  </span>
+</div>
 `;

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./Tooltip";
+export { default, position } from "./Tooltip";
 export type { Props as TooltipProps } from "./Tooltip";


### PR DESCRIPTION
## Done
- fix Tooltip accessibility
  - Tooltip child elements will now have a correct description attached via `aria-describedby`
  - allowing clicking links within the tooltip
  - fix focus handling (allowing to click elements within the tooltip and shifting focus via tab key appropriately)
- enable Tooltip component Storybook controls 
- migrate tests to @testing-library-react
- add integration tests
- add cypress test

## Screenshots
### Before
![Kapture 2022-04-11 at 16 10 50](https://user-images.githubusercontent.com/7452681/162758097-197c92cb-4169-466c-954a-d68da7e767b2.gif)

### After
![Kapture 2022-04-11 at 16 05 46](https://user-images.githubusercontent.com/7452681/162757162-d8a64dfc-b614-4015-bfad-838fdc05dc5a.gif)

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Make sure that you can access the link inside of the tooltip via tab and the button has a correct description via `aria-describedby`

## Fixes

Fixes: https://github.com/canonical-web-and-design/react-components/issues/697
Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/809
