### PR TITLE
feat: allow custom help text class

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -36,6 +36,10 @@ export type Props = {
    */
   help?: ReactNode;
   /**
+   * Optional class(es) to pass to the help text element.
+   */
+  helpClassName?: ReactNode;
+  /**
    * An id to give to the help element.
    */
   helpId?: string;
@@ -80,11 +84,12 @@ export type Props = {
 const generateHelpText = ({
   help,
   helpId,
+  helpClassName,
   isTickElement,
-}: Pick<Props, "help" | "helpId" | "isTickElement">) =>
+}: Pick<Props, "help" | "helpId" | "helpClassName" | "isTickElement">) =>
   help ? (
     <p
-      className={classNames("p-form-help-text", {
+      className={classNames("p-form-help-text", helpClassName, {
         "is-tick-element": isTickElement,
       })}
       id={helpId}
@@ -138,6 +143,7 @@ const generateContent = ({
   labelFirst,
   labelNode,
   help,
+  helpClassName,
   error,
   caution,
   success,
@@ -159,6 +165,7 @@ const generateContent = ({
     {generateHelpText({
       helpId,
       help,
+      helpClassName,
       isTickElement,
     })}
     {generateError(error, caution, success, validationId)}
@@ -172,6 +179,7 @@ const Field = ({
   error,
   forId,
   help,
+  helpClassName,
   helpId,
   isSelect,
   isTickElement,
@@ -198,6 +206,7 @@ const Field = ({
     labelFirst,
     labelNode,
     help,
+    helpClassName,
     error,
     caution,
     success,

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -21,6 +21,11 @@ import Input from "./Input";
         type: "text",
       },
     },
+    helpClassName: {
+      control: {
+        type: "text",
+      },
+    },
     label: {
       control: {
         type: "text",
@@ -67,6 +72,7 @@ An input field where the user can enter data, which can vary in many ways, depen
       placeholder: "example@canonical.com",
       label: "Email address",
       help: "Additional description for the field",
+      helpClassName: "u-no-margin--bottom",
     }}
   >
     {Template.bind({})}

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -5,13 +5,6 @@ import React from "react";
 import Input from "./Input";
 
 describe("Input", () => {
-  it("can add additional classes", () => {
-    const wrapper = shallow(<Input type="text" className="extra-class" />);
-    const className = wrapper.find("input").prop("className");
-    expect(className.includes("p-form-validation__input")).toBe(true);
-    expect(className.includes("extra-class")).toBe(true);
-  });
-
   it("moves the label for radio buttons", () => {
     const wrapper = shallow(<Input type="radio" />);
     expect(wrapper.prop("label")).toBe("");
@@ -111,5 +104,24 @@ describe("Input RTL", () => {
     const help = "Save me!";
     render(<Input help={help} type="checkbox" />);
     expect(screen.getByRole("checkbox")).toHaveAccessibleDescription(help);
+  });
+
+  it("can add additional classes", () => {
+    const { container } = render(
+      <Input
+        type="text"
+        className="extra-class"
+        help="additional description"
+        helpClassName="additional-help-text-class"
+      />
+    );
+    expect(screen.getByRole("textbox")).toHaveClass(
+      "p-form-validation__input",
+      "extra-class"
+    );
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector(".p-form-help-text")).toHaveClass(
+      "additional-help-text-class"
+    );
   });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -31,6 +31,10 @@ export type Props = PropsWithSpread<
      */
     help?: ReactNode;
     /**
+     * Optional class(es) to pass to the help text element.
+     */
+    helpClassName?: ReactNode;
+    /**
      * The id of the input.
      */
     id?: string;
@@ -71,6 +75,7 @@ const Input = ({
   className,
   error,
   help,
+  helpClassName,
   id,
   label,
   labelClassName,
@@ -138,6 +143,7 @@ const Input = ({
       error={error}
       forId={id}
       help={help}
+      helpClassName={helpClassName}
       helpId={helpId}
       isTickElement={type === "checkbox" || type === "radio"}
       label={fieldLabel}


### PR DESCRIPTION
## Done

- allow custom help text class

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/react-components/issues/760
