### PR TITLE
fix: tooltip on click should remain open until dismissed

### DIFF
--- a/cypress/integration/tooltip.spec.js
+++ b/cypress/integration/tooltip.spec.js
@@ -8,4 +8,35 @@ context("Tooltip", () => {
     cy.findByRole("button", { name: /Hover over me!/ }).click();
     cy.findByRole("tooltip").should("be.visible");
   });
+
+  it("hovering the child button element opens the tooltip", () => {
+    cy.findByRole("tooltip").should("not.be.visible");
+    cy.findByRole("button", { name: /Hover over me!/ }).trigger("mouseover");
+    cy.findByRole("tooltip").should("be.visible");
+  });
+
+  it("when activated on click tooltip remains open when the cursor is moved outside", () => {
+    cy.findByRole("tooltip").should("not.be.visible");
+    cy.findByRole("button", { name: /Hover over me!/ }).click();
+    cy.get("body").trigger("mousemove", { clientX: 0, clientY: 0 });
+    cy.findByRole("tooltip").should("be.visible");
+    cy.get("body").type("{esc}");
+    cy.findByRole("tooltip").should("not.be.visible");
+  });
+
+  it("when activated on click tooltip can be closed with an ESC key", () => {
+    cy.findByRole("tooltip").should("not.be.visible");
+    cy.findByRole("button", { name: /Hover over me!/ }).click();
+    cy.findByRole("tooltip").should("be.visible");
+    cy.get("body").type("{esc}");
+    cy.findByRole("tooltip").should("not.be.visible");
+  });
+
+  it("when activated on click tooltip can be closed by clicking outside of it", () => {
+    cy.findByRole("tooltip").should("not.be.visible");
+    cy.findByRole("button", { name: /Hover over me!/ }).click();
+    cy.findByRole("tooltip").should("be.visible");
+    cy.get("body").click(0, 0);
+    cy.findByRole("tooltip").should("not.be.visible");
+  });
 });

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "test-cypress": "concurrently 'yarn run docs' 'yarn run cypress:test' -k -s first",
     "unlink-packages": "yarn unlink && cd node_modules/react && yarn unlink && cd ../react-dom && yarn unlink",
     "cypress:test": "wait-on http://localhost:${PORT:-9009} && cypress run --env port=${PORT:-9009}",
-    "cypress:run": "cypress run",
-    "cypress:open": "cypress open"
+    "cypress:run": "cypress run --env port=${PORT:-9009}",
+    "cypress:open": "cypress open --env port=${PORT:-9009}"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -243,15 +243,24 @@ const Tooltip = ({
     autoAdjust && followMouse
   );
 
+  const handleKeyPress = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closePortal();
+      }
+    },
+    [closePortal]
+  );
+
   useEffect(() => {
-    window.addEventListener("keypress", closePortal);
+    window.addEventListener("keypress", handleKeyPress);
     return () => {
-      window.removeEventListener("keypress", closePortal);
+      window.removeEventListener("keypress", handleKeyPress);
     };
-  }, [closePortal]);
+  }, [handleKeyPress]);
 
   const handleBlur = (e) => {
-    // do not close if the focus is within the tooltip
+    // do not close if the focus is within the tooltip wrapper
     if (wrapperRef?.current?.contains(document.activeElement)) {
       return;
     }
@@ -266,6 +275,10 @@ const Tooltip = ({
   };
 
   const handleClick = (e) => {
+    // ignore clicks within the tooltip message
+    if (messageRef.current?.contains(e.target)) {
+      return;
+    }
     e.target.focus();
     openPortal();
   };

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -243,7 +243,19 @@ const Tooltip = ({
     autoAdjust && followMouse
   );
 
+  useEffect(() => {
+    window.addEventListener("keypress", closePortal);
+    return () => {
+      window.removeEventListener("keypress", closePortal);
+    };
+  }, [closePortal]);
+
   const handleBlur = (e) => {
+    // do not close if the focus is within the tooltip
+    if (wrapperRef?.current?.contains(document.activeElement)) {
+      return;
+    }
+
     if (
       e.relatedTarget
         ? !messageRef.current?.contains(e.relatedTarget)
@@ -253,12 +265,18 @@ const Tooltip = ({
     }
   };
 
+  const handleClick = (e) => {
+    e.target.focus();
+    openPortal();
+  };
+
   return (
     <>
       {message ? (
         <span
           className={className}
           onBlur={handleBlur}
+          onClick={handleClick}
           onFocus={openPortal}
           onMouseOut={handleBlur}
           onMouseOver={openPortal}


### PR DESCRIPTION
## Done

- fix: tooltip on click should remain open until dismissed
  - add cypress tests
  - add missing default port number to cypress commands

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check that the tooltip behaves as expected when activating on hover / keypress and can be dismissed
- You can use cypress test descriptions as a guidance

## Fixes

Fixes: https://github.com/canonical-web-and-design/react-components/issues/759
