### PR TITLE
[MainTable] Use conditional operator in onClick 

### DIFF
--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -164,14 +164,15 @@ const generateHeaders = (
         key={index}
         sort={sortDirection}
         onClick={
-          sortable &&
-          updateSort.bind(
-            this,
-            setSortKey,
-            setSortDirection,
-            sortKey,
-            sortDirection
-          )
+          sortable
+            ? updateSort.bind(
+                this,
+                setSortKey,
+                setSortDirection,
+                sortKey,
+                sortDirection
+              )
+            : undefined
         }
         {...props}
       >


### PR DESCRIPTION
## Done

For the MainTable component: if `sortable` is false then [this onClick handler](https://github.com/canonical-web-and-design/react-components/blob/main/src/components/MainTable/MainTable.tsx#L166) evaluates to `false` too, with two consequences:

- React shows a warning because it's not a function
- When clicking a column header an error is thrown

(see [example](https://codesandbox.io/s/headless-monad-fg0lk5))

Changing the `condition && value` syntax into a conditional operator as suggested in the warning seems to solve it.


## QA

- Open demo or `dotrun`
- Check that the sortable MainTable behaves as usual