### PR TITLE
fix(List): uneven middot spacing

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -93,6 +93,7 @@ const generateItems = ({
         {...liProps}
       >
         {body}
+        {/* middot variant in Vanilla relies on whitespace between inline elements for correct spacing */}
         {middot ? " " : null}
       </li>
     );

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -36,12 +36,13 @@ export type Props = {
   ticked?: boolean;
 } & Omit<HTMLProps<HTMLOListElement>, "type">;
 
-const generateItems = (
-  items: ListItem[],
-  ticked: boolean,
-  inline: boolean,
-  stepped: boolean
-) =>
+const generateItems = ({
+  items,
+  ticked,
+  inline,
+  middot,
+  stepped,
+}: Pick<Props, "items" | "ticked" | "inline" | "middot" | "stepped">) =>
   items.map((item, i) => {
     let body: ReactNode;
     let title: ReactNode;
@@ -92,6 +93,7 @@ const generateItems = (
         {...liProps}
       >
         {body}
+        {middot ? " " : null}
       </li>
     );
   });
@@ -126,7 +128,13 @@ const List = ({
       })}
       {...props}
     >
-      {generateItems(items, ticked, inline || middot || stretch, stepped)}
+      {generateItems({
+        items,
+        ticked,
+        inline: inline || middot || stretch,
+        middot,
+        stepped,
+      })}
     </Component>
   );
 };


### PR DESCRIPTION
## Done

- fix uneven middot spacing in a `List` component
- append a white space character at the end of each item if it's a `middot` list

### Note
CSS white space wrapping will prevent this space from being larger in case a component is already supplying items with a space appended to the end (2 spaces will be reduced to 1).

### Before
![image](https://user-images.githubusercontent.com/7452681/168058983-698f9576-2255-46e9-b715-9d7388318f13.png)

### After
![image](https://user-images.githubusercontent.com/7452681/168059120-9441d67c-4611-471f-9ca2-20806b068a8c.png)


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/896
Fixes: https://github.com/canonical-web-and-design/react-components/issues/773
