### PR TITLE
Allow both React v17 and v18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "postcss": "^8.3.11"
   },
   "peerDependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0",
     "vanilla-framework": "3.6.0"
   },
   "scripts": {


### PR DESCRIPTION
## Done

- Allow using react-components with React v18 as peer dependency.

## QA

- Review if code change in package.json is correct