### PR TITLE
fix: hide Navigation toggle when there are no items to display

### DIFF
--- a/src/components/Navigation/Navigation.stories.mdx
+++ b/src/components/Navigation/Navigation.stories.mdx
@@ -280,3 +280,21 @@ this function so take care in overriding any link props.
     {Template.bind({})}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story
+    name="No menu items"
+    args={{
+      generateLink: ({ url, label, isSelected, ...props }) => (
+        <button {...props}>{label}</button>
+      ),
+      logo: {
+        src: "https://assets.ubuntu.com/v1/82818827-CoF_white.svg",
+        title: "Canonical",
+        url: "#",
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/Navigation/Navigation.test.tsx
+++ b/src/components/Navigation/Navigation.test.tsx
@@ -7,6 +7,13 @@ import Navigation from "./Navigation";
 import { Theme } from "../../enums";
 import { isNavigationAnchor } from "../../utils";
 
+const items = [
+  {
+    label: "THIS IS A LINK",
+    url: "/this/is/the/url",
+  },
+];
+
 /* eslint-disable testing-library/no-node-access */
 it("displays light theme", () => {
   render(<Navigation logo={<img src="" alt="" />} theme={Theme.LIGHT} />);
@@ -272,6 +279,7 @@ it("closes the search form when the escape key is pressed", () => {
 it("closes the search form when opening the mobile menu", () => {
   render(
     <Navigation
+      items={items}
       logo={<img src="" alt="" />}
       searchProps={{ onSearch: jest.fn() }}
     />
@@ -305,6 +313,7 @@ it("closes the search form when clicking on the overlay", () => {
 it("closes the mobile menu when opening the search form", () => {
   render(
     <Navigation
+      items={items}
       logo={<img src="" alt="" />}
       searchProps={{ onSearch: jest.fn() }}
     />
@@ -319,11 +328,25 @@ it("closes the mobile menu when opening the search form", () => {
 });
 
 it("can open the mobile menu", () => {
-  render(<Navigation logo={<img src="" alt="" />} />);
+  render(<Navigation items={items} logo={<img src="" alt="" />} />);
   const banner = screen.getByRole("banner");
   expect(banner.className.includes("has-menu-open")).toBe(false);
   userEvent.click(screen.getByRole("button", { name: "Menu" }));
   expect(banner.className.includes("has-menu-open")).toBe(true);
+});
+
+it("hides the mobile menu button when there are no navigation items to display", () => {
+  render(
+    <Navigation
+      items={undefined}
+      itemsRight={undefined}
+      logo={<img src="" alt="" />}
+    />
+  );
+  const banner = screen.getByRole("banner");
+  expect(
+    within(banner).queryByRole("button", { name: "Menu" })
+  ).not.toBeInTheDocument();
 });
 
 it("closes the mobile menu when clicking on a nav link", () => {

--- a/src/components/Navigation/Navigation.test.tsx
+++ b/src/components/Navigation/Navigation.test.tsx
@@ -337,11 +337,7 @@ it("can open the mobile menu", () => {
 
 it("hides the mobile menu button when there are no navigation items to display", () => {
   render(
-    <Navigation
-      items={undefined}
-      itemsRight={undefined}
-      logo={<img src="" alt="" />}
-    />
+    <Navigation items={[]} itemsRight={[]} logo={<img src="" alt="" />} />
   );
   const banner = screen.getByRole("banner");
   expect(

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -234,15 +234,17 @@ const Navigation = ({
                 </li>
               ) : null
             }
-            <li className="p-navigation__item">
-              <button
-                aria-pressed={mobileMenuOpen}
-                className="p-navigation__link"
-                onClick={toggleMobileMenu}
-              >
-                {mobileMenuOpen ? "Close menu" : "Menu"}
-              </button>
-            </li>
+            {items?.length > 0 || itemsRight?.length > 0 ? (
+              <li className="p-navigation__item">
+                <button
+                  aria-pressed={mobileMenuOpen}
+                  className="p-navigation__link"
+                  onClick={toggleMobileMenu}
+                >
+                  {mobileMenuOpen ? "Close menu" : "Menu"}
+                </button>
+              </li>
+            ) : null}
           </ul>
         </div>
         <nav className="p-navigation__nav" {...navProps}>


### PR DESCRIPTION
## Done

- hide Navigation toggle when there are no items to display

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open storybook and verify that the [navigation variant with no menu items](https://react-components-803.demos.haus/?path=/story/navigation--no-menu-items) does not display the menu toggle when resized to a mobile breakpoint

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/4049
